### PR TITLE
[TASK] Prepare for TYPO3 10

### DIFF
--- a/Classes/AbstractDataHandlerListener.php
+++ b/Classes/AbstractDataHandlerListener.php
@@ -48,12 +48,18 @@ abstract class AbstractDataHandlerListener
     protected $configurationAwareRecordService;
 
     /**
+     * @var FrontendEnvironment
+     */
+    protected $frontendEnvironment = null;
+
+    /**
      * AbstractDataHandlerListener constructor.
      * @param ConfigurationAwareRecordService|null $recordService
      */
-    public function __construct(ConfigurationAwareRecordService $recordService = null)
+    public function __construct(ConfigurationAwareRecordService $recordService = null, FrontendEnvironment $frontendEnvironment = null)
     {
         $this->configurationAwareRecordService = $recordService ?? GeneralUtility::makeInstance(ConfigurationAwareRecordService::class);
+        $this->frontendEnvironment = $frontendEnvironment ?? GeneralUtility::makeInstance(FrontendEnvironment::class);
     }
 
     /**
@@ -115,7 +121,7 @@ abstract class AbstractDataHandlerListener
         $isRecursiveUpdateRequired = $this->isRecursiveUpdateRequired($pageId, $changedFields);
         // If RecursiveUpdateTriggerConfiguration is false => check if changeFields are part of recursiveUpdateFields
         if ($isRecursiveUpdateRequired === false) {
-            $solrConfiguration = Util::getSolrConfigurationFromPageId($pageId);
+            $solrConfiguration = $this->frontendEnvironment->getSolrConfigurationFromPageId($pageId);
             $indexQueueConfigurationName = $this->configurationAwareRecordService->getIndexingConfigurationName('pages', $pageId, $solrConfiguration);
             $updateFields = $solrConfiguration->getIndexQueueConfigurationRecursiveUpdateFields($indexQueueConfigurationName);
 

--- a/Classes/ConnectionManager.php
+++ b/Classes/ConnectionManager.php
@@ -31,16 +31,9 @@ use ApacheSolrForTypo3\Solr\System\Records\SystemLanguage\SystemLanguageReposito
 use ApacheSolrForTypo3\Solr\System\Solr\Node;
 use ApacheSolrForTypo3\Solr\System\Solr\SolrConnection;
 use InvalidArgumentException;
-use RuntimeException;
-use stdClass;
-use TYPO3\CMS\Core\Context\Context;
-use TYPO3\CMS\Core\Context\LanguageAspectFactory;
 use TYPO3\CMS\Core\Registry;
 use TYPO3\CMS\Core\SingletonInterface;
-use TYPO3\CMS\Core\TypoScript\ExtendedTemplateService;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Core\Utility\RootlineUtility;
-use TYPO3\CMS\Frontend\Page\PageRepository;
 use function json_encode;
 
 /**
@@ -71,12 +64,17 @@ class ConnectionManager implements SingletonInterface
      */
     protected $siteRepository;
 
+
     /**
      * @param SystemLanguageRepository $systemLanguageRepository
      * @param PagesRepositoryAtExtSolr|null $pagesRepositoryAtExtSolr
      * @param SiteRepository $siteRepository
      */
-    public function __construct(SystemLanguageRepository $systemLanguageRepository = null, PagesRepositoryAtExtSolr $pagesRepositoryAtExtSolr = null, SiteRepository $siteRepository = null)
+    public function __construct(
+        SystemLanguageRepository $systemLanguageRepository = null,
+        PagesRepositoryAtExtSolr $pagesRepositoryAtExtSolr = null,
+        SiteRepository $siteRepository = null
+    )
     {
         $this->systemLanguageRepository = $systemLanguageRepository ?? GeneralUtility::makeInstance(SystemLanguageRepository::class);
         $this->siteRepository           = $siteRepository ?? GeneralUtility::makeInstance(SiteRepository::class);
@@ -378,97 +376,6 @@ class ConnectionManager implements SingletonInterface
         }
 
         return $configuredSolrConnections;
-    }
-
-    /**
-     * Gets the configured Solr connection for a specific root page and language ID.
-     *
-     * @param array $rootPage A root page record with at least title and uid
-     * @param int $languageId ID of a system language
-     * @return array A solr connection configuration.
-     * @deprecated will be removed in v11, use SiteRepository
-     */
-    protected function getConfiguredSolrConnectionByRootPage(array $rootPage, $languageId)
-    {
-        trigger_error('solr:deprecation: Method getConfiguredSolrConnectionByRootPage is deprecated since EXT:solr 10 and will be removed in v11, use sitehandling instead', E_USER_DEPRECATED);
-
-        $connection = [];
-
-        $languageId = (int)$languageId;
-
-        $context = GeneralUtility::makeInstance(Context::class);
-        $languageAspect = LanguageAspectFactory::createFromTypoScript($GLOBALS['TSFE']->config['config'] ?? []);
-        $context->setAspect('language', GeneralUtility::makeInstance(
-            LanguageAspect::class,
-            $languageId,
-            $languageAspect->getContentId(),
-            $languageAspect->getOverlayType(),
-            $languageAspect->getFallbackChain())
-        );
-        $connectionKey = $rootPage['uid'] . '|' . $languageId;
-
-        $pageSelect = GeneralUtility::makeInstance(PageRepository::class);
-
-        $rootlineUtility = GeneralUtility::makeInstance(RootlineUtility::class, $rootPage['uid']);
-        try {
-            $rootLine = $rootlineUtility->get();
-        } catch (RuntimeException $e) {
-            $rootLine = [];
-        }
-
-        $tmpl = GeneralUtility::makeInstance(ExtendedTemplateService::class);
-        $tmpl->tt_track = false; // Do not log time-performance information
-        $tmpl->init();
-        $tmpl->runThroughTemplates($rootLine); // This generates the constants/config + hierarchy info for the template.
-
-        // fake micro TSFE to get correct condition parsing
-        $GLOBALS['TSFE'] = new stdClass();
-        $GLOBALS['TSFE']->tmpl = new stdClass();
-        $GLOBALS['TSFE']->cObjectDepthCounter = 50;
-        $GLOBALS['TSFE']->tmpl->rootLine = $rootLine;
-        // @extensionScannerIgnoreLine
-        $GLOBALS['TSFE']->sys_page = $pageSelect;
-        $GLOBALS['TSFE']->id = $rootPage['uid'];
-        $GLOBALS['TSFE']->page = $rootPage;
-
-        $tmpl->generateConfig();
-        $GLOBALS['TSFE']->tmpl->setup = $tmpl->setup;
-
-        $configuration = Util::getSolrConfigurationFromPageId($rootPage['uid'], false, $languageId);
-
-        $solrIsEnabledAndConfigured = $configuration->getEnabled() && $configuration->getSolrHasConnectionConfiguration();
-        if (!$solrIsEnabledAndConfigured) {
-            return $connection;
-        }
-
-        $connection = [
-            'connectionKey' => $connectionKey,
-            'rootPageTitle' => $rootPage['title'],
-            'rootPageUid' => $rootPage['uid'],
-            'read' => [
-                'scheme' => $configuration->getSolrScheme(),
-                'host' => $configuration->getSolrHost(),
-                'port' => $configuration->getSolrPort(),
-                'path' => $configuration->getSolrPath(),
-                'username' => $configuration->getSolrUsername(),
-                'password' => $configuration->getSolrPassword(),
-                'timeout' => $configuration->getSolrTimeout()
-            ],
-            'write' => [
-                'scheme' => $configuration->getSolrScheme('http', 'write'),
-                'host' => $configuration->getSolrHost('localhost', 'write'),
-                'port' => $configuration->getSolrPort(8983, 'write'),
-                'path' => $configuration->getSolrPath('/solr/core_en/', 'write'),
-                'username' => $configuration->getSolrUsername('', 'write'),
-                'password' => $configuration->getSolrPassword('', 'write'),
-                'timeout' => $configuration->getSolrTimeout(0, 'write')
-            ],
-
-            'language' => $languageId
-        ];
-
-        $connection['label'] = $this->buildConnectionLabel($connection);
-        return $connection;
     }
 
     /**

--- a/Classes/FrontendEnvironment.php
+++ b/Classes/FrontendEnvironment.php
@@ -1,0 +1,66 @@
+<?php
+namespace ApacheSolrForTypo3\Solr;
+
+
+use ApacheSolrForTypo3\Solr\FrontendEnvironment\Tsfe;
+use ApacheSolrForTypo3\Solr\FrontendEnvironment\TypoScript;
+use TYPO3\CMS\Core\Exception\SiteNotFoundException;
+use TYPO3\CMS\Core\SingletonInterface;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+
+class FrontendEnvironment implements SingletonInterface
+{
+
+    /**
+     * @var TypoScript
+     */
+    private $typoScript = null;
+
+    /**
+     * @var Tsfe
+     */
+    private $tsfe = null;
+
+    public function __construct(Tsfe $tsfe = null, TypoScript $typoScript = null)
+    {
+        $this->tsfe = $tsfe ?? GeneralUtility::makeInstance(Tsfe::class);
+        $this->typoScript = $typoScript ?? GeneralUtility::makeInstance(TypoScript::class);
+    }
+
+    public function changeLanguageContext(int $pageId, int $language): void
+    {
+        $this->tsfe->changeLanguageContext($pageId, $language);
+    }
+
+    /**
+     * Initializes the TSFE for a given page ID and language.
+     *
+     * @param $pageId
+     * @param int $language
+     * @throws SiteNotFoundException
+     * @throws \TYPO3\CMS\Core\Error\Http\ServiceUnavailableException
+     * @throws \TYPO3\CMS\Core\Http\ImmediateResponseException
+     */
+    public function initializeTsfe($pageId, $language = 0)
+    {
+        $this->tsfe->initializeTsfe($pageId, $language);
+    }
+
+    public function getConfigurationFromPageId($pageId, $path, $language = 0)
+    {
+        return $this->typoScript->getConfigurationFromPageId($pageId, $path, $language);
+    }
+
+    public function isAllowedPageType(array $pageRecord, $configurationName = 'pages'): bool
+    {
+        $configuration = $this->getConfigurationFromPageId($pageRecord['uid'], '');
+        $allowedPageTypes = $configuration->getIndexQueueAllowedPageTypesArrayByConfigurationName($configurationName);
+        return in_array($pageRecord['doktype'], $allowedPageTypes);
+    }
+
+    public function getSolrConfigurationFromPageId($pageId, $language = 0)
+    {
+        return $this->getConfigurationFromPageId($pageId, '', $language);
+    }
+}

--- a/Classes/FrontendEnvironment/Tsfe.php
+++ b/Classes/FrontendEnvironment/Tsfe.php
@@ -1,0 +1,142 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\FrontendEnvironment;
+
+use TYPO3\CMS\Core\Context\Context;
+use TYPO3\CMS\Core\Context\LanguageAspectFactory;
+use TYPO3\CMS\Core\Exception\SiteNotFoundException;
+use TYPO3\CMS\Core\SingletonInterface;
+use TYPO3\CMS\Core\Site\SiteFinder;
+use TYPO3\CMS\Core\TypoScript\TemplateService;
+use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
+use TYPO3\CMS\Backend\Utility\BackendUtility;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Frontend\Page\PageRepository;
+use TYPO3\CMS\Core\Context\UserAspect;
+use TYPO3\CMS\Frontend\Authentication\FrontendUserAuthentication;
+use TYPO3\CMS\Core\Http\ServerRequest;
+use ApacheSolrForTypo3\Solr\Util;
+
+class Tsfe implements SingletonInterface
+{
+
+    private $tsfeCache = [];
+
+    private $requestCache = [];
+
+    public function changeLanguageContext(int $pageId, int $language): void
+    {
+        $context = GeneralUtility::makeInstance(Context::class);
+        if ($context->hasAspect('language')) {
+            if ($context->getPropertyFromAspect('language', 'id') === $language) {
+                return;
+            }
+        }
+
+        $siteFinder = GeneralUtility::makeInstance(SiteFinder::class);
+        try {
+            $site = $siteFinder->getSiteByPageId($pageId);
+            $languageAspect = LanguageAspectFactory::createFromSiteLanguage($site->getLanguageById($language));
+            $context->setAspect('language', $languageAspect);
+        } catch (SiteNotFoundException $e) {
+
+        }
+    }
+
+    /**
+     * Initializes the TSFE for a given page ID and language.
+     *
+     * @param $pageId
+     * @param int $language
+     * @throws SiteNotFoundException
+     * @throws \TYPO3\CMS\Core\Error\Http\ServiceUnavailableException
+     * @throws \TYPO3\CMS\Core\Http\ImmediateResponseException
+     */
+    public function initializeTsfe($pageId, $language = 0)
+    {
+
+        // resetting, a TSFE instance with data from a different page Id could be set already
+        unset($GLOBALS['TSFE']);
+
+        $cacheId = $pageId . '|' . $language;
+
+        /** @var Context $context */
+        $context = GeneralUtility::makeInstance(Context::class);
+        $this->changeLanguageContext((int)$pageId, (int)$language);
+
+        if (!isset($this->requestCache[$cacheId])) {
+            $siteFinder = GeneralUtility::makeInstance(SiteFinder::class);
+            $site = $siteFinder->getSiteByPageId($pageId);
+            $siteLanguage = $site->getLanguageById($language);
+
+            $request = GeneralUtility::makeInstance(ServerRequest::class);
+            $request = $request->withAttribute('site', $site);
+            $this->requestCache[$cacheId] = $request->withAttribute('language', $siteLanguage);
+        }
+        $GLOBALS['TYPO3_REQUEST'] = $this->requestCache[$cacheId];
+
+        if (!isset($this->tsfeCache[$cacheId])) {
+
+            if (Util::getIsTYPO3VersionBelow10()) {
+                $GLOBALS['TSFE'] = GeneralUtility::makeInstance(TypoScriptFrontendController::class, [], $pageId, 0);
+            } else {
+                $GLOBALS['TSFE'] = GeneralUtility::makeInstance(TypoScriptFrontendController::class, $context, $site, $siteLanguage);
+                $GLOBALS['TSFE']->id = $pageId;
+                $GLOBALS['TSFE']->type = 0;
+            }
+
+            // for certain situations we need to trick TSFE into granting us
+            // access to the page in any case to make getPageAndRootline() work
+            // see http://forge.typo3.org/issues/42122
+            $pageRecord = BackendUtility::getRecord('pages', $pageId, 'fe_group');
+
+            $feUser = GeneralUtility::makeInstance(FrontendUserAuthentication::class);
+            $userGroups = [0, -1];
+            if (!empty($pageRecord['fe_group'])) {
+                $userGroups = array_unique(array_merge($userGroups, explode(',', $pageRecord['fe_group'])));
+            }
+            $context->setAspect('frontend.user', GeneralUtility::makeInstance(UserAspect::class, $feUser, $userGroups));
+
+            // @extensionScannerIgnoreLine
+            $GLOBALS['TSFE']->sys_page = GeneralUtility::makeInstance(PageRepository::class);
+            $GLOBALS['TSFE']->getPageAndRootlineWithDomain($pageId);
+
+            $template = GeneralUtility::makeInstance(TemplateService::class, $context);
+            $GLOBALS['TSFE']->tmpl = $template;
+            $GLOBALS['TSFE']->forceTemplateParsing = true;
+            $GLOBALS['TSFE']->no_cache = true;
+            $GLOBALS['TSFE']->tmpl->start($GLOBALS['TSFE']->rootLine);
+            $GLOBALS['TSFE']->no_cache = false;
+            $GLOBALS['TSFE']->getConfigArray();
+            $GLOBALS['TSFE']->settingLanguage();
+
+            $GLOBALS['TSFE']->newCObj();
+            $GLOBALS['TSFE']->absRefPrefix = self::getAbsRefPrefixFromTSFE($GLOBALS['TSFE']);
+            $GLOBALS['TSFE']->calculateLinkVars([]);
+
+            $this->tsfeCache[$cacheId] = $GLOBALS['TSFE'];
+        }
+
+        $GLOBALS['TSFE'] = $this->tsfeCache[$cacheId];
+        $GLOBALS['TSFE']->settingLocale();
+        $this->changeLanguageContext((int)$pageId, (int)$language);
+    }
+
+    /**
+     * Resolves the configured absRefPrefix to a valid value and resolved if absRefPrefix
+     * is set to "auto".
+     */
+    private function getAbsRefPrefixFromTSFE(TypoScriptFrontendController $TSFE): string
+    {
+        $absRefPrefix = '';
+        if (empty($TSFE->config['config']['absRefPrefix'])) {
+            return $absRefPrefix;
+        }
+
+        $absRefPrefix = trim($TSFE->config['config']['absRefPrefix']);
+        if ($absRefPrefix === 'auto') {
+            $absRefPrefix = GeneralUtility::getIndpEnv('TYPO3_SITE_PATH');
+        }
+
+        return $absRefPrefix;
+    }
+}

--- a/Classes/FrontendEnvironment/TypoScript.php
+++ b/Classes/FrontendEnvironment/TypoScript.php
@@ -1,0 +1,132 @@
+<?php
+namespace ApacheSolrForTypo3\Solr\FrontendEnvironment;
+
+use ApacheSolrForTypo3\Solr\FrontendEnvironment;
+use ApacheSolrForTypo3\Solr\System\Cache\TwoLevelCache;
+use ApacheSolrForTypo3\Solr\System\Configuration\ConfigurationManager;
+use ApacheSolrForTypo3\Solr\System\Configuration\ConfigurationPageResolver;
+use ApacheSolrForTypo3\Solr\System\Configuration\ExtensionConfiguration;
+use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
+use TYPO3\CMS\Core\SingletonInterface;
+use TYPO3\CMS\Core\TypoScript\ExtendedTemplateService;
+use TYPO3\CMS\Core\Utility\RootlineUtility;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+
+class TypoScript implements SingletonInterface
+{
+
+    private $configurationObjectCache = [];
+
+
+    /**
+     * Loads the TypoScript configuration for a given page id and language.
+     * Language usage may be disabled to get the default TypoScript
+     * configuration.
+     *
+     * @param int $pageId Id of the (root) page to get the Solr configuration from.
+     * @param string $path The TypoScript configuration path to retrieve.
+     * @param int $language System language uid, optional, defaults to 0
+     * @return TypoScriptConfiguration The Solr configuration for the requested tree.
+     */
+    public function getConfigurationFromPageId($pageId, $path, $language = 0)
+    {
+        $pageId = $this->getConfigurationPageIdToUse($pageId);
+
+        $cacheId = md5($pageId . '|' . $path . '|' . $language);
+        if (isset($this->configurationObjectCache[$cacheId])) {
+            return $this->configurationObjectCache[$cacheId];
+        }
+
+        // If we're on UID 0, we cannot retrieve a configuration currently.
+        // getRootline() below throws an exception (since #typo3-60 )
+        // as UID 0 cannot have any parent rootline by design.
+        if ($pageId == 0) {
+            return $this->configurationObjectCache[$cacheId] = $this->buildTypoScriptConfigurationFromArray([], $pageId, $language, $path);
+        }
+
+        /** @var $cache TwoLevelCache */
+        $cache = GeneralUtility::makeInstance(TwoLevelCache::class, /** @scrutinizer ignore-type */ 'tx_solr_configuration');
+        $configurationArray = $cache->get($cacheId);
+
+
+        if (!empty($configurationArray)) {
+            // we have a cache hit and can return it.
+            return $this->configurationObjectCache[$cacheId] = $this->buildTypoScriptConfigurationFromArray($configurationArray, $pageId, $language, $path);
+        }
+
+        // we have nothing in the cache. We need to build the configurationToUse
+        $configurationArray = $this->buildConfigurationArray($pageId, $path, $language);
+
+        $cache->set($cacheId, $configurationArray);
+
+        return $this->configurationObjectCache[$cacheId] = $this->buildTypoScriptConfigurationFromArray($configurationArray, $pageId, $language, $path);
+    }
+
+    /**
+     * This method retrieves the closest pageId where a configuration is located, when this
+     * feature is enabled.
+     *
+     * @param int $pageId
+     * @return int
+     */
+    private function getConfigurationPageIdToUse($pageId)
+    {
+        $extensionConfiguration = GeneralUtility::makeInstance(ExtensionConfiguration::class);
+        if ($extensionConfiguration->getIsUseConfigurationFromClosestTemplateEnabled()) {
+            /** @var $configurationPageResolve ConfigurationPageResolver */
+            $configurationPageResolver = GeneralUtility::makeInstance(ConfigurationPageResolver::class);
+            $pageId = $configurationPageResolver->getClosestPageIdWithActiveTemplate($pageId);
+            return $pageId;
+        }
+        return $pageId;
+    }
+
+    /**
+     * builds an configuration array, containing the solr configuration.
+     *
+     * @param integer $pageId
+     * @param string $path
+     * @param integer $language
+     * @return array
+     */
+    private function buildConfigurationArray($pageId, $path, $language)
+    {
+        if (is_int($language)) {
+            GeneralUtility::makeInstance(FrontendEnvironment::class)->changeLanguageContext((int)$pageId, (int)$language);
+        }
+        $rootlineUtility = GeneralUtility::makeInstance(RootlineUtility::class, $pageId);
+        try {
+            $rootLine = $rootlineUtility->get();
+        } catch (\RuntimeException $e) {
+            $rootLine = [];
+        }
+
+        /** @var $tmpl ExtendedTemplateService */
+        $tmpl = GeneralUtility::makeInstance(ExtendedTemplateService::class);
+        $tmpl->tt_track = false; // Do not log time-performance information
+        $tmpl->runThroughTemplates($rootLine); // This generates the constants/config + hierarchy info for the template.
+        $tmpl->generateConfig();
+
+        $getConfigurationFromInitializedTSFEAndWriteToCache = $tmpl->ext_getSetup($tmpl->setup, $path);
+        $configurationToUse = $getConfigurationFromInitializedTSFEAndWriteToCache[0];
+
+        return is_array($configurationToUse) ? $configurationToUse : [];
+    }
+
+    /**
+     * Builds the configuration object from a config array and returns it.
+     *
+     * @param array $configurationToUse
+     * @param int $pageId
+     * @param int $languageId
+     * @param string $typoScriptPath
+     * @return TypoScriptConfiguration
+     */
+    private function buildTypoScriptConfigurationFromArray(array $configurationToUse, $pageId, $languageId, $typoScriptPath)
+    {
+        $configurationManager = GeneralUtility::makeInstance(ConfigurationManager::class);
+        return $configurationManager->getTypoScriptConfiguration($configurationToUse, $pageId, $languageId, $typoScriptPath);
+    }
+
+}

--- a/Classes/GarbageCollector.php
+++ b/Classes/GarbageCollector.php
@@ -339,7 +339,7 @@ class GarbageCollector extends AbstractDataHandlerListener implements SingletonI
      */
     protected function isIndexablePageType(array $record)
     {
-        return Util::isAllowedPageType($record);
+        return $this->frontendEnvironment->isAllowedPageType($record);
     }
 
     /**

--- a/Classes/IndexQueue/PageIndexer.php
+++ b/Classes/IndexQueue/PageIndexer.php
@@ -397,4 +397,5 @@ class PageIndexer extends Indexer
     {
         return Rootline::getAccessRootlineByPageId($pageId, $mountPointParameter);
     }
+
 }

--- a/Classes/IndexQueue/RecordMonitor.php
+++ b/Classes/IndexQueue/RecordMonitor.php
@@ -28,6 +28,7 @@ use ApacheSolrForTypo3\Solr\AbstractDataHandlerListener;
 use ApacheSolrForTypo3\Solr\Domain\Index\Queue\RecordMonitor\Helper\ConfigurationAwareRecordService;
 use ApacheSolrForTypo3\Solr\Domain\Index\Queue\RecordMonitor\Helper\MountPagesUpdater;
 use ApacheSolrForTypo3\Solr\Domain\Index\Queue\RecordMonitor\Helper\RootPageResolver;
+use ApacheSolrForTypo3\Solr\FrontendEnvironment;
 use ApacheSolrForTypo3\Solr\GarbageCollector;
 use ApacheSolrForTypo3\Solr\System\Configuration\ExtensionConfiguration;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
@@ -86,6 +87,11 @@ class RecordMonitor extends AbstractDataHandlerListener
     protected $logger = null;
 
     /**
+     * @var FrontendEnvironment
+     */
+    protected $frontendEnvironment = null;
+
+    /**
      * RecordMonitor constructor.
      *
      * @param Queue|null $indexQueue
@@ -96,7 +102,16 @@ class RecordMonitor extends AbstractDataHandlerListener
      * @param SolrLogManager|null $solrLogManager
      * @param ConfigurationAwareRecordService|null $recordService
      */
-    public function __construct(Queue $indexQueue = null, MountPagesUpdater $mountPageUpdater = null, TCAService $TCAService = null, RootPageResolver $rootPageResolver = null, PagesRepository $pagesRepository = null, SolrLogManager $solrLogManager = null, ConfigurationAwareRecordService $recordService = null)
+    public function __construct(
+        Queue $indexQueue = null,
+        MountPagesUpdater $mountPageUpdater = null,
+        TCAService $TCAService = null,
+        RootPageResolver $rootPageResolver = null,
+        PagesRepository $pagesRepository = null,
+        SolrLogManager $solrLogManager = null,
+        ConfigurationAwareRecordService $recordService = null,
+        FrontendEnvironment $frontendEnvironment = null
+    )
     {
         parent::__construct($recordService);
         $this->indexQueue = $indexQueue ?? GeneralUtility::makeInstance(Queue::class);
@@ -105,6 +120,7 @@ class RecordMonitor extends AbstractDataHandlerListener
         $this->rootPageResolver = $rootPageResolver ?? GeneralUtility::makeInstance(RootPageResolver::class);
         $this->pagesRepository = $pagesRepository ?? GeneralUtility::makeInstance(PagesRepository::class);
         $this->logger = $solrLogManager ?? GeneralUtility::makeInstance(SolrLogManager::class, /** @scrutinizer ignore-type */ __CLASS__);
+        $this->frontendEnvironment = $frontendEnvironment ?? GeneralUtility::makeInstance(FrontendEnvironment::class);
     }
 
     /**
@@ -560,8 +576,8 @@ class RecordMonitor extends AbstractDataHandlerListener
      * @param int $language
      * @return TypoScriptConfiguration
      */
-    protected function getSolrConfigurationFromPageId($pageId, $initializeTsfe = false, $language = 0)
+    protected function getSolrConfigurationFromPageId($pageId)
     {
-        return Util::getSolrConfigurationFromPageId($pageId, $initializeTsfe, $language);
+        return $this->frontendEnvironment->getSolrConfigurationFromPageId($pageId);
     }
 }

--- a/Classes/Report/SolrConfigurationStatus.php
+++ b/Classes/Report/SolrConfigurationStatus.php
@@ -24,6 +24,7 @@ namespace ApacheSolrForTypo3\Solr\Report;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
+use ApacheSolrForTypo3\Solr\FrontendEnvironment;
 use ApacheSolrForTypo3\Solr\System\Configuration\ExtensionConfiguration;
 use ApacheSolrForTypo3\Solr\System\Records\Pages\PagesRepository;
 use ApacheSolrForTypo3\Solr\System\Records\SystemDomain\SystemDomainRepository;
@@ -52,14 +53,24 @@ class SolrConfigurationStatus extends AbstractSolrStatus
     protected $extensionConfiguration;
 
     /**
+     * @var FrontendEnvironment
+     */
+    protected $fronendEnvironment = null;
+
+    /**
      * SolrConfigurationStatus constructor.
      * @param SystemDomainRepository|null $systemDomainRepository
      * @param ExtensionConfiguration|null $extensionConfiguration
      */
-    public function __construct(SystemDomainRepository $systemDomainRepository = null, ExtensionConfiguration $extensionConfiguration = null)
+    public function __construct(
+        SystemDomainRepository $systemDomainRepository = null,
+        ExtensionConfiguration $extensionConfiguration = null,
+        FrontendEnvironment $frontendEnvironment = null
+    )
     {
         $this->systemDomainRepository = $systemDomainRepository ?? GeneralUtility::makeInstance(SystemDomainRepository::class);
         $this->extensionConfiguration = $extensionConfiguration ?? GeneralUtility::makeInstance(ExtensionConfiguration::class);
+        $this->fronendEnvironment = $frontendEnvironment ?? GeneralUtility::makeInstance(FrontendEnvironment::class);
     }
 
     /**
@@ -279,6 +290,6 @@ class SolrConfigurationStatus extends AbstractSolrStatus
      */
     protected function initializeTSFE($rootPage)
     {
-        Util::initializeTsfe($rootPage['uid']);
+        $this->fronendEnvironment->initializeTsfe($rootPage['uid']);
     }
 }

--- a/Classes/System/UserFunctions/FlexFormUserFunctions.php
+++ b/Classes/System/UserFunctions/FlexFormUserFunctions.php
@@ -21,7 +21,7 @@ namespace ApacheSolrForTypo3\Solr\System\UserFunctions;
  */
 
 use ApacheSolrForTypo3\Solr\ConnectionManager;
-use ApacheSolrForTypo3\Solr\Util;
+use ApacheSolrForTypo3\Solr\FrontendEnvironment;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 
@@ -32,6 +32,17 @@ use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
  */
 class FlexFormUserFunctions
 {
+
+    /**
+     * @var FrontendEnvironment
+     */
+    protected $frontendEnvironment = null;
+
+    public function __construct(FrontendEnvironment $frontendEnvironment = null)
+    {
+        $this->frontendEnvironment = $frontendEnvironment ?? GeneralUtility::makeInstance(FrontendEnvironment::class);
+    }
+
     /**
      * Provides all facet fields for a flexform select, enabling the editor to select one of them.
      *
@@ -173,7 +184,7 @@ class FlexFormUserFunctions
      */
     protected function getConfigurationFromPageId($pid)
     {
-        $typoScriptConfiguration = Util::getSolrConfigurationFromPageId($pid);
+        $typoScriptConfiguration = $this->frontendEnvironment->getSolrConfigurationFromPageId($pid);
         return $typoScriptConfiguration;
     }
 

--- a/Classes/Util.php
+++ b/Classes/Util.php
@@ -45,6 +45,7 @@ use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Frontend\Page\PageRepository;
 use TYPO3\CMS\Core\Context\UserAspect;
 use TYPO3\CMS\Frontend\Authentication\FrontendUserAuthentication;
+use TYPO3\CMS\Core\Http\ServerRequest;
 
 /**
  * Utility class for tx_solr
@@ -102,7 +103,6 @@ class Util
 
     /**
      * Shortcut to retrieve the TypoScript configuration for EXT:solr
-     * (plugin.tx_solr) from TSFE.
      *
      * @return TypoScriptConfiguration
      */
@@ -117,14 +117,16 @@ class Util
      * To be used from the backend.
      *
      * @param int $pageId Id of the (root) page to get the Solr configuration from.
-     * @param bool $initializeTsfe Optionally initializes a full TSFE to get the configuration, defaults to FALSE
      * @param int $language System language uid, optional, defaults to 0
      * @return TypoScriptConfiguration The Solr configuration for the requested tree.
      */
     public static function getSolrConfigurationFromPageId($pageId, $initializeTsfe = false, $language = 0)
     {
-        $rootPath = '';
-        return self::getConfigurationFromPageId($pageId, $rootPath, $initializeTsfe, $language);
+        trigger_error('Method getSolrConfigurationFromPageId is deprecated since EXT:solr 11 and will be removed in v12, use FrontendEnvironment directly.', E_USER_DEPRECATED);
+        if ($initializeTsfe === true) {
+            GeneralUtility::makeInstance(FrontendEnvironment::class)->initializeTsfe($pageId, $language);
+        }
+        return GeneralUtility::makeInstance(FrontendEnvironment::class)->getSolrConfigurationFromPageId($pageId, $language);
     }
 
     /**
@@ -134,274 +136,37 @@ class Util
      *
      * @param int $pageId Id of the (root) page to get the Solr configuration from.
      * @param string $path The TypoScript configuration path to retrieve.
-     * @param bool $initializeTsfe Optionally initializes a full TSFE to get the configuration, defaults to FALSE
+     * @param bool $initializeTsfe
      * @param int $language System language uid, optional, defaults to 0
      * @param bool $useTwoLevelCache Flag to enable the two level cache for the typoscript configuration array
      * @return TypoScriptConfiguration The Solr configuration for the requested tree.
      */
     public static function getConfigurationFromPageId($pageId, $path, $initializeTsfe = false, $language = 0, $useTwoLevelCache = true)
     {
-        $pageId = self::getConfigurationPageIdToUse($pageId);
-
-        static $configurationObjectCache = [];
-        $cacheId = md5($pageId . '|' . $path . '|' . $language . '|' . ($initializeTsfe ? '1' : '0'));
-        if (isset($configurationObjectCache[$cacheId])) {
-            if ($initializeTsfe) {
-                self::initializeTsfe($pageId, $language);
-            }
-            return $configurationObjectCache[$cacheId];
+        trigger_error('Method getConfigurationFromPageId is deprecated since EXT:solr 11 and will be removed in v12, use FrontendEnvironment directly.', E_USER_DEPRECATED);
+        if ($initializeTsfe === true) {
+            GeneralUtility::makeInstance(FrontendEnvironment::class)->initializeTsfe($pageId, $language);
         }
-
-        // If we're on UID 0, we cannot retrieve a configuration currently.
-        // getRootline() below throws an exception (since #typo3-60 )
-        // as UID 0 cannot have any parent rootline by design.
-        if ($pageId == 0) {
-            return $configurationObjectCache[$cacheId] = self::buildTypoScriptConfigurationFromArray([], $pageId, $language, $path);
-        }
-
-        if ($useTwoLevelCache) {
-            /** @var $cache TwoLevelCache */
-            $cache = GeneralUtility::makeInstance(TwoLevelCache::class, /** @scrutinizer ignore-type */ 'tx_solr_configuration');
-            $configurationArray = $cache->get($cacheId);
-        }
-
-        if (!empty($configurationArray)) {
-            // we have a cache hit and can return it.
-            if ($initializeTsfe) {
-                self::initializeTsfe($pageId, $language);
-            }
-            return $configurationObjectCache[$cacheId] = self::buildTypoScriptConfigurationFromArray($configurationArray, $pageId, $language, $path);
-        }
-
-        // we have nothing in the cache. We need to build the configurationToUse
-        $configurationArray = self::buildConfigurationArray($pageId, $path, $initializeTsfe, $language);
-
-        if ($useTwoLevelCache && isset($cache)) {
-            $cache->set($cacheId, $configurationArray);
-        }
-
-        return $configurationObjectCache[$cacheId] = self::buildTypoScriptConfigurationFromArray($configurationArray, $pageId, $language, $path);
+        return GeneralUtility::makeInstance(FrontendEnvironment::class)->getConfigurationFromPageId($pageId, $path, $language);
     }
 
-    /**
-     * This method retrieves the closest pageId where a configuration is located, when this
-     * feature is enabled.
-     *
-     * @param int $pageId
-     * @return int
-     */
-    protected static function getConfigurationPageIdToUse($pageId)
-    {
-        $extensionConfiguration = GeneralUtility::makeInstance(ExtensionConfiguration::class);
-        if ($extensionConfiguration->getIsUseConfigurationFromClosestTemplateEnabled()) {
-            /** @var $configurationPageResolve ConfigurationPageResolver */
-            $configurationPageResolver = GeneralUtility::makeInstance(ConfigurationPageResolver::class);
-            $pageId = $configurationPageResolver->getClosestPageIdWithActiveTemplate($pageId);
-            return $pageId;
-        }
-        return $pageId;
-    }
-
-    /**
-     * Initializes a TSFE, if required and builds an configuration array, containing the solr configuration.
-     *
-     * @param integer $pageId
-     * @param string $path
-     * @param boolean $initializeTsfe
-     * @param integer $language
-     * @return array
-     */
-    protected static function buildConfigurationArray($pageId, $path, $initializeTsfe, $language)
-    {
-        if ($initializeTsfe) {
-            self::initializeTsfe($pageId, $language);
-            $configurationToUse = self::getConfigurationFromInitializedTSFE($path);
-        } else {
-            $configurationToUse = self::getConfigurationFromExistingTSFE($pageId, $path, $language);
-        }
-
-        return is_array($configurationToUse) ? $configurationToUse : [];
-    }
-
-    /**
-     * Builds the configuration object from a config array and returns it.
-     *
-     * @param array $configurationToUse
-     * @param int $pageId
-     * @param int $languageId
-     * @param string $typoScriptPath
-     * @return TypoScriptConfiguration
-     */
-    protected static function buildTypoScriptConfigurationFromArray(array $configurationToUse, $pageId, $languageId, $typoScriptPath)
-    {
-        $configurationManager = GeneralUtility::makeInstance(ConfigurationManager::class);
-        return $configurationManager->getTypoScriptConfiguration($configurationToUse, $pageId, $languageId, $typoScriptPath);
-    }
-
-    /**
-     * This function is used to retrieve the configuration from a previous initialized TSFE
-     * (see: getConfigurationFromPageId)
-     *
-     * @param string $path
-     * @return mixed
-     */
-    private static function getConfigurationFromInitializedTSFE($path)
-    {
-        /** @var $tmpl ExtendedTemplateService */
-        $tmpl = GeneralUtility::makeInstance(ExtendedTemplateService::class);
-        $configuration = $tmpl->ext_getSetup($GLOBALS['TSFE']->tmpl->setup, $path);
-        $configurationToUse = $configuration[0];
-        return $configurationToUse;
-    }
-
-    /**
-     * @param int $pageId
-     * @param int $language
-     */
-    private static function changeLanguageContext(int $pageId, int $language): void
-    {
-        $context = GeneralUtility::makeInstance(Context::class);
-        if ($context->hasAspect('language')) {
-            if ($context->getPropertyFromAspect('language', 'id') === $language) {
-                return;
-            }
-        }
-
-        $siteFinder = GeneralUtility::makeInstance(SiteFinder::class);
-        try {
-            $site = $siteFinder->getSiteByPageId($pageId);
-            $languageAspect = LanguageAspectFactory::createFromSiteLanguage($site->getLanguageById($language));
-            $context->setAspect('language', $languageAspect);
-        } catch (SiteNotFoundException $e) {
-            // legacy site
-            if ($context->hasAspect('language')) {
-                $languageAspect = $context->getAspect('language');
-                $context->setAspect('language', GeneralUtility::makeInstance(
-                    LanguageAspect::class,
-                    (int)$language,
-                    $languageAspect->getContentId(),
-                    $languageAspect->getOverlayType(),
-                    $languageAspect->getFallbackChain()
-                ));
-            } else {
-                $context->setAspect('language', GeneralUtility::makeInstance(
-                    LanguageAspect::class,
-                    (int)$language
-                ));
-            }
-        }
-    }
-
-    /**
-     * This function is used to retrieve the configuration from an existing TSFE instance
-     *
-     * @param $pageId
-     * @param $path
-     * @param $language
-     * @return mixed
-     */
-    private static function getConfigurationFromExistingTSFE($pageId, $path, $language)
-    {
-        if (is_int($language)) {
-            self::changeLanguageContext((int)$pageId, (int)$language);
-        }
-        $rootlineUtility = GeneralUtility::makeInstance(RootlineUtility::class, $pageId);
-        try {
-            $rootLine = $rootlineUtility->get();
-        } catch (\RuntimeException $e) {
-            $rootLine = [];
-        }
-
-            /** @var $tmpl ExtendedTemplateService */
-        $tmpl = GeneralUtility::makeInstance(ExtendedTemplateService::class);
-        $tmpl->tt_track = false; // Do not log time-performance information
-        $tmpl->runThroughTemplates($rootLine); // This generates the constants/config + hierarchy info for the template.
-        $tmpl->generateConfig();
-
-        $getConfigurationFromInitializedTSFEAndWriteToCache = $tmpl->ext_getSetup($tmpl->setup, $path);
-        $configurationToUse = $getConfigurationFromInitializedTSFEAndWriteToCache[0];
-
-        return $configurationToUse;
-    }
 
     /**
      * Initializes the TSFE for a given page ID and language.
      *
-     * @param int $pageId The page id to initialize the TSFE for
-     * @param int $language System language uid, optional, defaults to 0
-     * @param bool $useCache Use cache to reuse TSFE
-     * @todo When we drop TYPO3 8 support we should use a middleware stack to initialize a TSFE for our needs
-     * @return void
+     * @param $pageId
+     * @param int $language
+     * @param bool $useCache
+     * @throws SiteNotFoundException
+     * @throws \TYPO3\CMS\Core\Error\Http\ServiceUnavailableException
+     * @throws \TYPO3\CMS\Core\Http\ImmediateResponseException
      */
     public static function initializeTsfe($pageId, $language = 0, $useCache = true)
     {
-        static $tsfeCache = [];
-
-        // resetting, a TSFE instance with data from a different page Id could be set already
-        unset($GLOBALS['TSFE']);
-
-        $cacheId = $pageId . '|' . $language;
-
-        /** @var Context $context */
-        $context = GeneralUtility::makeInstance(Context::class);
-        self::changeLanguageContext((int)$pageId, (int)$language);
-
-        if (!isset($tsfeCache[$cacheId])) {
-
-            $GLOBALS['TSFE'] = GeneralUtility::makeInstance(TypoScriptFrontendController::class, $GLOBALS['TYPO3_CONF_VARS'], $pageId, 0);
-
-            // for certain situations we need to trick TSFE into granting us
-            // access to the page in any case to make getPageAndRootline() work
-            // see http://forge.typo3.org/issues/42122
-            $pageRecord = BackendUtility::getRecord('pages', $pageId, 'fe_group');
-
-            $feUser = GeneralUtility::makeInstance(FrontendUserAuthentication::class);
-            $userGroups = [0, -1];
-            if (!empty($pageRecord['fe_group'])) {
-                $userGroups = array_unique(array_merge($userGroups, explode(',', $pageRecord['fe_group'])));
-            }
-            $context->setAspect('frontend.user', GeneralUtility::makeInstance(UserAspect::class, $feUser, $userGroups));
-
-            // @extensionScannerIgnoreLine
-            $GLOBALS['TSFE']->sys_page = GeneralUtility::makeInstance(PageRepository::class);
-            self::getPageAndRootlineOfTSFE($pageId);
-
-            $template = GeneralUtility::makeInstance(TemplateService::class, $context);
-            $GLOBALS['TSFE']->tmpl = $template;
-            $GLOBALS['TSFE']->forceTemplateParsing = true;
-            $GLOBALS['TSFE']->no_cache = true;
-            $GLOBALS['TSFE']->tmpl->start($GLOBALS['TSFE']->rootLine);
-            $GLOBALS['TSFE']->no_cache = false;
-            $GLOBALS['TSFE']->getConfigArray();
-            $GLOBALS['TSFE']->settingLanguage();
-
-            $GLOBALS['TSFE']->newCObj();
-            $GLOBALS['TSFE']->absRefPrefix = self::getAbsRefPrefixFromTSFE($GLOBALS['TSFE']);
-            $GLOBALS['TSFE']->calculateLinkVars();
-
-            $tsfeCache[$cacheId] = $GLOBALS['TSFE'];
-        }
-
-        $GLOBALS['TSFE'] = $tsfeCache[$cacheId];
-        $GLOBALS['TSFE']->settingLocale();
-        self::changeLanguageContext((int)$pageId, (int)$language);
+        trigger_error('Method initializeTsfe is deprecated since EXT:solr 11 and will be removed in v12, use FrontendEnvironment directly.', E_USER_DEPRECATED);
+        GeneralUtility::makeInstance(FrontendEnvironment::class)->initializeTsfe($pageId, $language);
     }
 
-    /**
-     * @deprecated This is only implemented to provide compatibility for TYPO3 8 and 9 when we drop TYPO3 8 support this
-     * should changed to use a middleware stack
-     * @param integer $pageId
-     */
-    private static function getPageAndRootlineOfTSFE($pageId)
-    {
-        //@todo When we drop the support of TYPO3 8 we should use the frontend middleware stack instead of initializing this on our own
-        /** @var $siteRepository SiteRepository */
-        $siteRepository = GeneralUtility::makeInstance(SiteRepository::class);
-        $site = $siteRepository->getSiteByPageId($pageId);
-        if (!is_null($site)) {
-            $GLOBALS['TSFE']->getPageAndRootlineWithDomain($site->getRootPageId());
-        }
-    }
 
     /**
      * Check if record ($table, $uid) is a workspace record
@@ -435,15 +200,8 @@ class Util
      */
     public static function isAllowedPageType(array $pageRecord, $configurationName = 'pages')
     {
-        $isAllowedPageType = false;
-        $configurationName = $configurationName ?? 'pages';
-        $allowedPageTypes = self::getAllowedPageTypes($pageRecord['uid'], $configurationName);
-
-        if (in_array($pageRecord['doktype'], $allowedPageTypes)) {
-            $isAllowedPageType = true;
-        }
-
-        return $isAllowedPageType;
+        trigger_error('Method isAllowedPageType is deprecated since EXT:solr 11 and will be removed in v12, use FrontendEnvironment directly.', E_USER_DEPRECATED);
+        return GeneralUtility::makeInstance(FrontendEnvironment::class)->isAllowedPageType($pageRecord, $configurationName);
     }
 
     /**
@@ -456,6 +214,7 @@ class Util
      */
     public static function getAllowedPageTypes($pageId, $configurationName = 'pages')
     {
+        trigger_error('Method getAllowedPageTypes is deprecated since EXT:solr 11 and will be removed in v12, no call required.', E_USER_DEPRECATED);
         $rootPath = '';
         $configuration = self::getConfigurationFromPageId($pageId, $rootPath);
         return $configuration->getIndexQueueAllowedPageTypesArrayByConfigurationName($configurationName);
@@ -470,6 +229,7 @@ class Util
      */
     public static function getAbsRefPrefixFromTSFE(TypoScriptFrontendController $TSFE)
     {
+        trigger_error('Method getAbsRefPrefixFromTSFE is deprecated since EXT:solr 11 and will be removed in v12, no call required.', E_USER_DEPRECATED);
         $absRefPrefix = '';
         if (empty($TSFE->config['config']['absRefPrefix'])) {
             return $absRefPrefix;

--- a/Resources/Private/Templates/Backend/Search/IndexQueueModule/Index.html
+++ b/Resources/Private/Templates/Backend/Search/IndexQueueModule/Index.html
@@ -129,7 +129,7 @@
 			<div class="row section-with-header">
 				<div class="col-md-3">
 
-					<f:form addQueryString="1" addQueryStringMethod="POST"
+					<f:form addQueryString="1"
 							additionalParams="{route: '/searchbackend/SolrIndexadministration/', tx_solr_searchbackend_solrindexadministration:{controller: 'Backend\\Search\\IndexAdministrationModule', action: 'clearIndexQueue', id: '{pageUID}', fromQueue: 'true'}}">
 						<f:form.submit class="btn btn-sm btn-default btn-danger t3js-modal-formsubmit-trigger"
 									   data="{title: 'Please confirm', content: 'Are you sure you want to clear the Index Queue?', severity: 'warning'}"

--- a/Tests/Integration/Controller/AbstractFrontendControllerTest.php
+++ b/Tests/Integration/Controller/AbstractFrontendControllerTest.php
@@ -40,7 +40,7 @@ abstract class AbstractFrontendControllerTest  extends IntegrationTest {
     protected function indexPages($importPageIds)
     {
         foreach ($importPageIds as $importPageId) {
-            $fakeTSFE = $this->getConfiguredTSFE([], $importPageId);
+            $fakeTSFE = $this->getConfiguredTSFE($importPageId);
             $GLOBALS['TSFE'] = $fakeTSFE;
             $fakeTSFE->newCObj();
 

--- a/Tests/Integration/Controller/SearchControllerTest.php
+++ b/Tests/Integration/Controller/SearchControllerTest.php
@@ -103,7 +103,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
     public function canShowSearchForm()
     {
         $this->importDataSetFromFixture('can_render_search_controller.xml');
-        $GLOBALS['TSFE'] = $this->getConfiguredTSFE([], 1);
+        $GLOBALS['TSFE'] = $this->getConfiguredTSFE(1);
 
         $this->indexPages([1, 2]);
 
@@ -119,7 +119,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
     {
         $_GET['q'] = 'prices';
         $this->importDataSetFromFixture('can_render_search_controller.xml');
-        $GLOBALS['TSFE'] = $this->getConfiguredTSFE([], 1);
+        $GLOBALS['TSFE'] = $this->getConfiguredTSFE(1);
         $this->indexPages([1, 2, 3]);
 
         $this->searchController->processRequest($this->searchRequest, $this->searchResponse);
@@ -136,7 +136,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
     public function canDoAPaginatedSearch()
     {
         $this->importDataSetFromFixture('can_render_search_controller.xml');
-        $GLOBALS['TSFE'] = $this->getConfiguredTSFE([], 1);
+        $GLOBALS['TSFE'] = $this->getConfiguredTSFE(1);
 
         $this->indexPages([1, 2, 3, 4, 5, 6, 7, 8]);
 
@@ -155,7 +155,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
     public function canOpenSecondPageOfPaginatedSearch()
     {
         $this->importDataSetFromFixture('can_render_search_controller.xml');
-        $GLOBALS['TSFE'] = $this->getConfiguredTSFE([], 1);
+        $GLOBALS['TSFE'] = $this->getConfiguredTSFE(1);
         $this->indexPages([1, 2, 3, 4, 5, 6, 7, 8]);
 
         //now we jump to the second page
@@ -175,7 +175,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
     public function canGetADidYouMeanProposalForATypo()
     {
         $this->importDataSetFromFixture('can_render_search_controller.xml');
-        $GLOBALS['TSFE'] = $this->getConfiguredTSFE([], 1);
+        $GLOBALS['TSFE'] = $this->getConfiguredTSFE(1);
 
         $this->indexPages([1, 2, 3, 4, 5, 6, 7, 8]);
 
@@ -194,7 +194,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
     public function canAutoCorrectATypo()
     {
         $this->importDataSetFromFixture('can_render_search_controller.xml');
-        $GLOBALS['TSFE'] = $this->getConfiguredTSFE([], 1);
+        $GLOBALS['TSFE'] = $this->getConfiguredTSFE(1);
 
         $this->indexPages([1, 2, 3, 4, 5, 6, 7, 8]);
 
@@ -223,7 +223,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
     public function canRenderAFacetWithFluid()
     {
         $this->importDataSetFromFixture('can_render_search_controller.xml');
-        $GLOBALS['TSFE'] = $this->getConfiguredTSFE([], 1);
+        $GLOBALS['TSFE'] = $this->getConfiguredTSFE(1);
 
         $this->indexPages([1, 2]);
 
@@ -245,7 +245,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
     public function canDoAnInitialEmptySearchWithoutResults()
     {
         $this->importDataSetFromFixture('can_render_search_controller.xml');
-        $GLOBALS['TSFE'] = $this->getConfiguredTSFE([], 1);
+        $GLOBALS['TSFE'] = $this->getConfiguredTSFE(1);
 
         $this->indexPages([1, 2, 3, 4, 5, 6, 7, 8]);
 
@@ -273,7 +273,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
     public function canDoAnInitialEmptySearchWithResults()
     {
         $this->importDataSetFromFixture('can_render_search_controller.xml');
-        $GLOBALS['TSFE'] = $this->getConfiguredTSFE([], 1);
+        $GLOBALS['TSFE'] = $this->getConfiguredTSFE(1);
 
         $this->indexPages([1, 2, 3, 4, 5, 6, 7, 8]);
 
@@ -302,7 +302,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
     {
 
         $this->importDataSetFromFixture('can_render_search_controller.xml');
-        $GLOBALS['TSFE'] = $this->getConfiguredTSFE([], 1);
+        $GLOBALS['TSFE'] = $this->getConfiguredTSFE(1);
 
         $this->indexPages([1, 2, 3, 4, 5, 6, 7, 8]);
 
@@ -330,7 +330,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
     public function canDoAnInitialSearchWithResults()
     {
         $this->importDataSetFromFixture('can_render_search_controller.xml');
-        $GLOBALS['TSFE'] = $this->getConfiguredTSFE([], 1);
+        $GLOBALS['TSFE'] = $this->getConfiguredTSFE(1);
 
         $this->indexPages([1, 2, 3, 4, 5, 6, 7, 8]);
 
@@ -357,7 +357,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
     public function removeOptionLinkWillBeShownWhenFacetWasSelected()
     {
         $this->importDataSetFromFixture('can_render_search_controller.xml');
-        $GLOBALS['TSFE'] = $this->getConfiguredTSFE([], 1);
+        $GLOBALS['TSFE'] = $this->getConfiguredTSFE(1);
 
         $this->indexPages([1, 2, 3, 4, 5, 6, 7, 8]);
 
@@ -379,7 +379,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
     public function removeOptionLinkWillIsAlsoShownWhenAFacetIsNotInTheResponse()
     {
         $this->importDataSetFromFixture('can_render_search_controller.xml');
-        $GLOBALS['TSFE'] = $this->getConfiguredTSFE([], 1);
+        $GLOBALS['TSFE'] = $this->getConfiguredTSFE(1);
 
         $this->indexPages([1, 2, 3, 4, 5, 6, 7, 8]);
 
@@ -401,7 +401,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
     public function canFilterOnPageSections()
     {
         $this->importDataSetFromFixture('can_render_search_controller.xml');
-        $GLOBALS['TSFE'] = $this->getConfiguredTSFE([], 1);
+        $GLOBALS['TSFE'] = $this->getConfiguredTSFE(1);
 
         $this->indexPages([1, 2, 3, 4, 5, 6, 7, 8]);
 
@@ -435,7 +435,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
         $this->expectExceptionMessageRegExp('#(.*The partial files.*NotFound.*|.*The Fluid template files .*NotFound.*)#');
 
         $this->importDataSetFromFixture('can_render_search_controller.xml');
-        $GLOBALS['TSFE'] = $this->getConfiguredTSFE([], 1);
+        $GLOBALS['TSFE'] = $this->getConfiguredTSFE(1);
 
         $this->indexPages([1, 2, 3, 4, 5, 6, 7, 8]);
 
@@ -461,7 +461,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
     public function canRenderAScoreAnalysisWhenBackendUserIsLoggedIn()
     {
         $this->importDataSetFromFixture('can_render_search_controller.xml');
-        $GLOBALS['TSFE'] = $this->getConfiguredTSFE([], 1);
+        $GLOBALS['TSFE'] = $this->getConfiguredTSFE(1);
 
         $this->indexPages([1, 2]);
 
@@ -482,7 +482,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
     public function canSortFacetsByLex()
     {
         $this->importDataSetFromFixture('can_render_search_controller.xml');
-        $GLOBALS['TSFE'] = $this->getConfiguredTSFE([], 1);
+        $GLOBALS['TSFE'] = $this->getConfiguredTSFE(1);
 
         $womanPages = [4,5,8];
         $menPages = [2];
@@ -523,7 +523,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
     public function canSortFacetsByOptionCountWhenNothingIsConfigured()
     {
         $this->importDataSetFromFixture('can_render_search_controller.xml');
-        $GLOBALS['TSFE'] = $this->getConfiguredTSFE([], 1);
+        $GLOBALS['TSFE'] = $this->getConfiguredTSFE(1);
 
         $womanPages = [4,5,8];
         $menPages = [2];
@@ -555,7 +555,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
     public function canRenderQueryGroupFacet()
     {
         $this->importDataSetFromFixture('can_render_search_controller.xml');
-        $GLOBALS['TSFE'] = $this->getConfiguredTSFE([], 1);
+        $GLOBALS['TSFE'] = $this->getConfiguredTSFE(1);
 
         $this->indexPages([1, 2, 3, 4, 5, 6, 7, 8]);
 
@@ -583,7 +583,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
 
         $this->importDataSetFromFixture('can_render_search_controller.xml');
 
-        $GLOBALS['TSFE'] = $this->getConfiguredTSFE([], 1);
+        $GLOBALS['TSFE'] = $this->getConfiguredTSFE(1);
 
         $this->indexPages([1, 2, 3, 4, 5, 6, 7, 8]);
 
@@ -613,7 +613,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
         }
 
         $this->importDataSetFromFixture('can_render_search_controller.xml');
-        $GLOBALS['TSFE'] = $this->getConfiguredTSFE([], 1);
+        $GLOBALS['TSFE'] = $this->getConfiguredTSFE(1);
 
         $this->indexPages([1, 2, 3, 4, 5, 6, 7, 8]);
 
@@ -643,7 +643,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
         }
 
         $this->importDataSetFromFixture('can_render_path_facet_with_search_controller.xml');
-        $GLOBALS['TSFE'] = $this->getConfiguredTSFE([], 1);
+        $GLOBALS['TSFE'] = $this->getConfiguredTSFE(1);
 
         $this->indexPages([1, 2, 3]);
         // we should have 3 documents in solr
@@ -669,7 +669,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
     public function canDefineAManualSortOrder()
     {
         $this->importDataSetFromFixture('can_render_search_controller.xml');
-        $GLOBALS['TSFE'] = $this->getConfiguredTSFE([], 1);
+        $GLOBALS['TSFE'] = $this->getConfiguredTSFE(1);
 
         $womanPages = [4,5,8];
         $menPages = [2];
@@ -711,7 +711,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
     public function canSeeTheParsedQueryWhenABackendUserIsLoggedIn()
     {
         $this->importDataSetFromFixture('can_render_search_controller.xml');
-        $GLOBALS['TSFE'] = $this->getConfiguredTSFE([], 1);
+        $GLOBALS['TSFE'] = $this->getConfiguredTSFE(1);
 
         $this->indexPages([1, 2]);
 
@@ -736,7 +736,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
         // set a wrong port where no solr is running
         $this->writeDefaultSolrTestSiteConfigurationForHostAndPort('http','localhost', 4711);
         $this->importDataSetFromFixture('can_render_error_message_when_solr_unavailable.xml');
-        $GLOBALS['TSFE'] = $this->getConfiguredTSFE([], 1);
+        $GLOBALS['TSFE'] = $this->getConfiguredTSFE(1);
 
         $this->searchRequest->setControllerActionName('solrNotAvailable');
         $this->searchController->processRequest($this->searchRequest, $this->searchResponse);
@@ -773,7 +773,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
         $this->expectExceptionCode(1476045801);
 
         $this->importDataSetFromFixture('can_render_error_message_when_solr_unavailable.xml');
-        $GLOBALS['TSFE'] = $this->getConfiguredTSFE([], 1);
+        $GLOBALS['TSFE'] = $this->getConfiguredTSFE(1);
 
         $_GET = $getArguments;
         $this->searchRequest->setControllerActionName($action);
@@ -786,7 +786,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
     public function canShowLastSearchesFromSessionInResponse()
     {
         $this->importDataSetFromFixture('can_render_search_controller.xml');
-        $GLOBALS['TSFE'] = $this->getConfiguredTSFE([], 1);
+        $GLOBALS['TSFE'] = $this->getConfiguredTSFE(1);
 
         $this->indexPages([1, 2, 3, 4, 5, 6, 7, 8]);
 
@@ -809,7 +809,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
     public function canChangeResultsPerPage()
     {
         $this->importDataSetFromFixture('can_render_search_controller.xml');
-        $GLOBALS['TSFE'] = $this->getConfiguredTSFE([], 1);
+        $GLOBALS['TSFE'] = $this->getConfiguredTSFE(1);
 
         $this->indexPages([1, 2, 3, 4, 5, 6, 7, 8]);
 
@@ -831,7 +831,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
     public function canShowLastSearchesFromDatabaseInResponse()
     {
         $this->importDataSetFromFixture('can_render_search_controller.xml');
-        $GLOBALS['TSFE'] = $this->getConfiguredTSFE([], 1);
+        $GLOBALS['TSFE'] = $this->getConfiguredTSFE(1);
 
         $this->indexPages([1, 2, 3, 4, 5, 6, 7, 8]);
 
@@ -861,7 +861,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
     public function canNotStoreQueyStringInLastSearchesWhenQueryDoesNotReturnAResult()
     {
         $this->importDataSetFromFixture('can_render_search_controller.xml');
-        $GLOBALS['TSFE'] = $this->getConfiguredTSFE([], 1);
+        $GLOBALS['TSFE'] = $this->getConfiguredTSFE(1);
 
         $this->indexPages([1, 2, 3, 4, 5, 6, 7, 8]);
 
@@ -891,7 +891,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
     public function canOverwriteAFilterWithTheFlexformSettings()
     {
         $this->importDataSetFromFixture('can_render_search_controller.xml');
-        $GLOBALS['TSFE'] = $this->getConfiguredTSFE([], 1);
+        $GLOBALS['TSFE'] = $this->getConfiguredTSFE(1);
 
         $this->indexPages([1, 2, 3, 4, 5, 6, 7, 8]);
 
@@ -913,7 +913,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
     public function canRenderDateRangeFacet()
     {
         $this->importDataSetFromFixture('can_render_search_controller.xml');
-        $GLOBALS['TSFE'] = $this->getConfiguredTSFE([], 1);
+        $GLOBALS['TSFE'] = $this->getConfiguredTSFE(1);
 
         $this->indexPages([1, 2, 3, 4, 5, 6, 7, 8]);
 
@@ -941,7 +941,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
     public function canRenderASecondFacetOnTheTypeField()
     {
         $this->importDataSetFromFixture('can_render_search_controller.xml');
-        $GLOBALS['TSFE'] = $this->getConfiguredTSFE([], 1);
+        $GLOBALS['TSFE'] = $this->getConfiguredTSFE(1);
 
         $this->indexPages([1, 2, 3, 4, 5, 6, 7, 8]);
 
@@ -974,7 +974,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
         }
 
         $this->importDataSetFromFixture('can_sort_by_metric.xml');
-        $GLOBALS['TSFE'] = $this->getConfiguredTSFE([], 1);
+        $GLOBALS['TSFE'] = $this->getConfiguredTSFE(1);
 
         $this->indexPages([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
 
@@ -1001,7 +1001,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
     public function formActionIsRenderingTheForm()
     {
         $this->importDataSetFromFixture('can_render_search_controller.xml');
-        $GLOBALS['TSFE'] = $this->getConfiguredTSFE([], 1);
+        $GLOBALS['TSFE'] = $this->getConfiguredTSFE(1);
 
         $formRequest = $this->getPreparedRequest('Search','form');
         $formResponse = $this->getPreparedResponse();
@@ -1017,7 +1017,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
     public function searchingAndRenderingFrequentSearchesIsShowingTheTermAsFrequentSearch()
     {
         $this->importDataSetFromFixture('can_render_search_controller.xml');
-        $GLOBALS['TSFE'] = $this->getConfiguredTSFE([], 1);
+        $GLOBALS['TSFE'] = $this->getConfiguredTSFE(1);
 
         $this->indexPages([1]);
 
@@ -1039,7 +1039,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
         $request->setArgument('documentId', '002de2729efa650191f82900ea02a0a3189dfabb/pages/1/0/0/0');
 
         $this->importDataSetFromFixture('can_render_search_controller.xml');
-        $GLOBALS['TSFE'] = $this->getConfiguredTSFE([], 1);
+        $GLOBALS['TSFE'] = $this->getConfiguredTSFE(1);
 
         $this->indexPages([1, 2]);
 
@@ -1055,7 +1055,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
         $request = $this->getPreparedRequest('Search', 'form', 'pi_search');
 
         $this->importDataSetFromFixture('can_render_search_controller.xml');
-        $GLOBALS['TSFE'] = $this->getConfiguredTSFE([], 1);
+        $GLOBALS['TSFE'] = $this->getConfiguredTSFE(1);
 
         $this->searchController->processRequest($request, $this->searchResponse);
         $this->assertContains('id="tx-solr-search-form-pi-results"', $this->searchResponse->getContent());
@@ -1071,7 +1071,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
         $_GET['q'] = '*';
 
         $this->importDataSetFromFixture('can_render_search_customTemplate.xml');
-        $GLOBALS['TSFE'] = $this->getConfiguredTSFE([], 1);
+        $GLOBALS['TSFE'] = $this->getConfiguredTSFE(1);
         $this->indexPages([1, 2, 3, 4, 5, 6, 7, 8]);
         $this->searchRequest->setArgument('resultsPerPage', 5);
         $this->searchController->processRequest($this->searchRequest, $this->searchResponse);
@@ -1089,7 +1089,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
         $_GET['q'] = '*';
 
         $this->importDataSetFromFixture('can_render_search_customTemplate.xml');
-        $GLOBALS['TSFE'] = $this->getConfiguredTSFE([], 1);
+        $GLOBALS['TSFE'] = $this->getConfiguredTSFE(1);
         $this->indexPages([1, 2, 3, 4, 5, 6, 7, 8]);
 
 
@@ -1117,7 +1117,7 @@ class SearchControllerTest extends AbstractFrontendControllerTest
     {
         $_GET['q'] = '*';
         $this->importDataSetFromFixture('can_render_search_customTemplateFromTs.xml');
-        $GLOBALS['TSFE'] = $this->getConfiguredTSFE([], 1);
+        $GLOBALS['TSFE'] = $this->getConfiguredTSFE(1);
         $this->indexPages([1, 2, 3, 4, 5, 6, 7, 8]);
         $this->searchRequest->setArgument('resultsPerPage', 5);
         $this->searchController->processRequest($this->searchRequest, $this->searchResponse);
@@ -1205,14 +1205,17 @@ class SearchControllerTest extends AbstractFrontendControllerTest
         $environmentServiceMock->expects($this->any())->method('isEnvironmentInFrontendMode')->willReturn(true);
         $environmentServiceMock->expects($this->any())->method('isEnvironmentInBackendMode')->willReturn(false);
 
-        $configurationManagerMock = $this->getMockBuilder(ExtbaseConfigurationManager::class)->setMethods(['getContentObject'])
-            ->setConstructorArgs([$this->objectManager, $environmentServiceMock])->getMock();
-        $configurationManagerMock->expects($this->any())->method('getContentObject')->willReturn(GeneralUtility::makeInstance(ContentObjectRenderer::class));
-
-        //@todo can be dropped when TYPO3 9 support will be dropped.
-        if(Util::getIsTYPO3VersionBelow10()) {
+        if (Util::getIsTYPO3VersionBelow10()) {
+            $configurationManagerMock = $this->getMockBuilder(ExtbaseConfigurationManager::class)->setMethods(['getContentObject'])->getMock();
+            $configurationManagerMock->injectObjectManager($this->objectManager);
+            $configurationManagerMock->injectEnvironmentService($environmentServiceMock);
             $environmentServiceMock->expects($this->any())->method('isEnvironmentInCliMode')->willReturn(false);
+        } else {
+            $configurationManagerMock = $this->getMockBuilder(ExtbaseConfigurationManager::class)->setMethods(['getContentObject'])
+                ->setConstructorArgs([$this->objectManager, $environmentServiceMock])->getMock();
         }
+
+        $configurationManagerMock->expects($this->any())->method('getContentObject')->willReturn(GeneralUtility::makeInstance(ContentObjectRenderer::class));
 
         GeneralUtility::setSingletonInstance(EnvironmentService::class, $environmentServiceMock);
         GeneralUtility::setSingletonInstance(ExtbaseConfigurationManager::class, $configurationManagerMock);

--- a/Tests/Integration/Controller/SuggestControllerTest.php
+++ b/Tests/Integration/Controller/SuggestControllerTest.php
@@ -91,7 +91,7 @@ class SuggestControllerTest extends AbstractFrontendControllerTest
     public function canDoABasicSuggest()
     {
         $this->importDataSetFromFixture('can_render_suggest_controller.xml');
-        $GLOBALS['TSFE'] = $this->getConfiguredTSFE([], 1);
+        $GLOBALS['TSFE'] = $this->getConfiguredTSFE(1);
         $this->indexPages([1, 2, 3, 4, 5, 6, 7, 8]);
 
         $this->suggestRequest->setArgument('queryString', 'Sweat');

--- a/Tests/Integration/Domain/Search/ResultSet/ResultSetReconstitutionProcessorTest.php
+++ b/Tests/Integration/Domain/Search/ResultSet/ResultSetReconstitutionProcessorTest.php
@@ -179,7 +179,8 @@ class ResultSetReconstitutionProcessorTest extends IntegrationTest
         $searchResultSet->getUsedSearchRequest()->expects($this->any())->method('getActiveFacetNames')->will($this->returnValue([]));
 
         $processor = new ResultSetReconstitutionProcessor();
-        $processor->setObjectManager(new FakeObjectManager());
+        $fakeObjectManager = $this->getFakeObjectManager();
+        $processor->setObjectManager($fakeObjectManager);
         return $processor;
     }
 

--- a/Tests/Integration/Domain/Search/ResultSet/SearchResultSetServiceTest.php
+++ b/Tests/Integration/Domain/Search/ResultSet/SearchResultSetServiceTest.php
@@ -30,8 +30,9 @@ use ApacheSolrForTypo3\Solr\Domain\Search\SearchRequest;
 use ApacheSolrForTypo3\Solr\Search;
 use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTest;
 use ApacheSolrForTypo3\Solr\Util;
-use TYPO3\CMS\Core\Http\ImmediateResponseException;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Object\ObjectManager;
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
 
 class SearchResultSetServiceTest extends IntegrationTest
 {
@@ -203,14 +204,18 @@ class SearchResultSetServiceTest extends IntegrationTest
     {
         $search = GeneralUtility::makeInstance(Search::class, $solrConnection);
         /** @var $searchResultsSetService SearchResultSetService */
-        $searchResultsSetService = GeneralUtility::makeInstance(SearchResultSetService::class, $typoScriptConfiguration, $search);
+        $searchResultSetService = GeneralUtility::makeInstance(SearchResultSetService::class, $typoScriptConfiguration, $search);
+
+        $fakeObjectManager = $this->getFakeObjectManager();
+
+        $searchResultSetService->injectObjectManager($fakeObjectManager);
 
         /** @var $searchRequest SearchRequest */
         $searchRequest = GeneralUtility::makeInstance(SearchRequest::class, [], 0, 0, $typoScriptConfiguration);
         $searchRequest->setRawQueryString($queryString);
         $searchRequest->setResultsPerPage(10);
 
-        $searchResultSet = $searchResultsSetService->search($searchRequest);
+        $searchResultSet = $searchResultSetService->search($searchRequest);
 
         $searchResults = $searchResultSet->getSearchResults();
         return $searchResults;

--- a/Tests/Integration/GarbageCollectorTest.php
+++ b/Tests/Integration/GarbageCollectorTest.php
@@ -222,10 +222,10 @@ class GarbageCollectorTest extends IntegrationTest
         // we expect the is one item in the indexQueue
         $this->assertIndexQueryContainsItemAmount(1);
         $items = $this->indexQueue->getItems('pages', 1);
+        $this->assertSame(1, count($items));
 
         // we index this item
-        $itemIds = $this->getItemPageIds($items);
-        $this->indexPageIds($itemIds);
+        $this->indexPageIds([1]);
         $this->waitToBeVisibleInSolr();
 
         // now the content of the deletec content element should be gone
@@ -272,11 +272,10 @@ class GarbageCollectorTest extends IntegrationTest
         // we expect the is one item in the indexQueue
         $this->assertIndexQueryContainsItemAmount(1);
         $items = $this->indexQueue->getItems('pages', 1);
-
-        $itemIds = $this->getItemPageIds($items);
-
+        $this->assertSame(1, count($items));
+        
         // we index this item
-        $this->indexPageIds($itemIds);
+        $this->indexPageIds([1]);
         $this->waitToBeVisibleInSolr();
 
         // now the content of the deletec content element should be gone
@@ -326,10 +325,10 @@ class GarbageCollectorTest extends IntegrationTest
         // we expect the is one item in the indexQueue
         $this->assertIndexQueryContainsItemAmount(1);
         $items = $this->indexQueue->getItems('pages', 1);
+        $this->assertSame(1, count($items));
 
-        $itemIds = $this->getItemPageIds($items);
         // we index this item
-        $this->indexPageIds($itemIds);
+        $this->indexPageIds([1]);
         $this->waitToBeVisibleInSolr();
 
         // now the content of the deletec content element should be gone
@@ -379,10 +378,10 @@ class GarbageCollectorTest extends IntegrationTest
 
         $this->assertIndexQueryContainsItemAmount(1);
         $items = $this->indexQueue->getItems('pages', 1);
+        $this->assertSame(1, count($items));
 
         // we index this item
-        $itemIds = $this->getItemPageIds($items);
-        $this->indexPageIds($itemIds);
+        $this->indexPageIds([1]);
         $this->waitToBeVisibleInSolr();
 
         // now the content of the deletec content element should be gone
@@ -431,10 +430,10 @@ class GarbageCollectorTest extends IntegrationTest
         // we expect the is one item in the indexQueue
         $this->assertIndexQueryContainsItemAmount(1);
         $items = $this->indexQueue->getItems('pages', 1);
+        $this->assertSame(1, count($items));
 
         // we index this item
-        $itemIds = $this->getItemPageIds($items);
-        $this->indexPageIds($itemIds);
+        $this->indexPageIds([1]);
         $this->waitToBeVisibleInSolr();
 
         // now the content of the deletec content element should be gone
@@ -606,20 +605,7 @@ class GarbageCollectorTest extends IntegrationTest
 
         return $result;
     }
-
-    /**
-     * @param $items
-     * @return array
-     */
-    protected function getItemPageIds($items):array
-    {
-        $itemIds = [];
-        foreach ($items as $item) {
-            /** @var $item Item */
-            $itemIds[] = $item->getRecordPageId();
-        }
-        return $itemIds;
-    }
+    
 
     /**
      *

--- a/Tests/Integration/IndexQueue/Fixtures/can_index_custom_record_outside_site_root_with_template.xml
+++ b/Tests/Integration/IndexQueue/Fixtures/can_index_custom_record_outside_site_root_with_template.xml
@@ -51,6 +51,7 @@
                                         typolink.parameter = 1
                                         typolink.useCacheHash = 1
                                         typolink.returnLast = url
+                                        typolink.forceAbsoluteUrl = 1
                                     }
                                 }
                             }

--- a/Tests/Integration/IndexQueue/Fixtures/can_index_custom_translated_record_with_l_param.xml
+++ b/Tests/Integration/IndexQueue/Fixtures/can_index_custom_translated_record_with_l_param.xml
@@ -8,9 +8,6 @@
         <clear>3</clear>
         <config>
             <![CDATA[
-                config.sys_language_mode = ignore
-                config.sys_language_uid = 0
-                config.linkVars = L
 
                 page = PAGE
                 page.typeNum = 0
@@ -55,17 +52,13 @@
                                         typolink.additionalParams.insertData = 1
                                         typolink.returnLast = url
                                         typolink.useCacheHash = 1
+                                        typolink.forceAbsoluteUrl = 1
                                     }
                                 }
                             }
                         }
                     }
                 }
-                [globalVar = GP:L = 1]
-                    plugin.tx_solr.solr.path = /solr/core_de/
-                    config.sys_language_uid = 1
-                [end]
-
             ]]>
         </config>
         <sorting>100</sorting>
@@ -117,7 +110,6 @@
         <title>German</title>
         <flag>de</flag>
         <language_isocode>de</language_isocode>
-        <static_lang_isocode>0</static_lang_isocode>
         <sorting>128</sorting>
     </sys_language>
 </dataset>

--- a/Tests/Integration/IndexQueue/Fixtures/can_index_custom_translated_record_with_mm_relation_to_a_page.xml
+++ b/Tests/Integration/IndexQueue/Fixtures/can_index_custom_translated_record_with_mm_relation_to_a_page.xml
@@ -129,7 +129,6 @@
         <title>German</title>
         <flag>de</flag>
         <language_isocode>de</language_isocode>
-        <static_lang_isocode>0</static_lang_isocode>
         <sorting>128</sorting>
     </sys_language>
 </dataset>

--- a/Tests/Integration/IndexQueue/Fixtures/can_index_custom_translated_record_without_l_param.xml
+++ b/Tests/Integration/IndexQueue/Fixtures/can_index_custom_translated_record_without_l_param.xml
@@ -8,9 +8,6 @@
         <clear>3</clear>
         <config>
             <![CDATA[
-                config.sys_language_mode = ignore
-                config.sys_language_uid = 0
-                config.linkVars = L
 
                 page = PAGE
                 page.typeNum = 0
@@ -55,17 +52,13 @@
                                         typolink.additionalParams.insertData = 1
                                         typolink.returnLast = url
                                         typolink.useCacheHash = 1
+                                        typolink.forceAbsoluteUrl = 1
                                     }
                                 }
                             }
                         }
                     }
                 }
-                [globalVar = GP:L = 1]
-                    plugin.tx_solr.solr.path = /solr/core_de/
-                    config.sys_language_uid = 1
-                [end]
-
             ]]>
         </config>
         <sorting>100</sorting>
@@ -118,7 +111,6 @@
         <title>German</title>
         <flag>de</flag>
         <language_isocode>de</language_isocode>
-        <static_lang_isocode>0</static_lang_isocode>
         <sorting>128</sorting>
     </sys_language>
 </dataset>

--- a/Tests/Integration/IndexQueue/Fixtures/can_index_custom_translated_record_without_l_param_and_content_fallback.xml
+++ b/Tests/Integration/IndexQueue/Fixtures/can_index_custom_translated_record_without_l_param_and_content_fallback.xml
@@ -7,10 +7,6 @@
         <clear>3</clear>
         <config>
             <![CDATA[
-                config.sys_language_overlay = hideNonTranslated
-                config.sys_language_mode = content_fallback; 0
-                config.sys_language_uid = 0
-                config.linkVars = L
 
                 page = PAGE
                 page.typeNum = 0
@@ -55,16 +51,13 @@
                                         typolink.additionalParams.insertData = 1
                                         typolink.returnLast = url
                                         typolink.useCacheHash = 1
+                                        typolink.forceAbsoluteUrl = 1
                                     }
                                 }
                             }
                         }
                     }
                 }
-                [globalVar = GP:L = 1]
-                    plugin.tx_solr.solr.path = /solr/core_de/
-                    config.sys_language_uid = 1
-                [end]
 
             ]]>
         </config>
@@ -75,27 +68,11 @@
         <is_siteroot>1</is_siteroot>
         <doktype>1</doktype>
     </pages>
-    <pages>
-        <uid>2</uid>
-        <is_siteroot>1</is_siteroot>
-        <l10n_parent>1</l10n_parent>
-        <sys_language_uid>1</sys_language_uid>
-        <doktype>1</doktype>
-        <hidden>0</hidden>
-        <deleted>0</deleted>
-    </pages>
+
     <tx_fakeextension_domain_model_bar>
         <uid>88</uid>
         <pid>1</pid>
         <title>original</title>
-    </tx_fakeextension_domain_model_bar>
-
-    <tx_fakeextension_domain_model_bar>
-        <uid>99</uid>
-        <pid>1</pid>
-        <title>translation</title>
-        <sys_language_uid>1</sys_language_uid>
-        <l10n_parent>88</l10n_parent>
     </tx_fakeextension_domain_model_bar>
 
 
@@ -105,14 +82,6 @@
         <title>original2</title>
     </tx_fakeextension_domain_model_bar>
 
-    <tx_fakeextension_domain_model_bar>
-        <uid>9999</uid>
-        <pid>1</pid>
-        <title>translation2</title>
-        <sys_language_uid>1</sys_language_uid>
-        <l10n_parent>777</l10n_parent>
-    </tx_fakeextension_domain_model_bar>
-
     <sys_language>
         <uid>1</uid>
         <pid>0</pid>
@@ -120,7 +89,6 @@
         <title>German</title>
         <flag>de</flag>
         <language_isocode>de</language_isocode>
-        <static_lang_isocode>0</static_lang_isocode>
         <sorting>128</sorting>
     </sys_language>
 </dataset>

--- a/Tests/Integration/IndexQueue/FrontendHelper/Fixtures/can_index_custom_pagetype_into_solr.xml
+++ b/Tests/Integration/IndexQueue/FrontendHelper/Fixtures/can_index_custom_pagetype_into_solr.xml
@@ -8,6 +8,7 @@
         <clear>3</clear>
         <config>
             <![CDATA[
+                config.index_enable = 1
                 page = PAGE
                 page.typeNum = 0
                 page.bodyTag = <body>

--- a/Tests/Integration/IndexQueue/FrontendHelper/Fixtures/can_index_into_solr.xml
+++ b/Tests/Integration/IndexQueue/FrontendHelper/Fixtures/can_index_into_solr.xml
@@ -8,6 +8,7 @@
         <clear>3</clear>
         <config>
             <![CDATA[
+                config.index_enable = 1
                 page = PAGE
                 page.typeNum = 0
                 page.bodyTag = <body>

--- a/Tests/Integration/IndexQueue/FrontendHelper/Fixtures/can_index_mounted_page.xml
+++ b/Tests/Integration/IndexQueue/FrontendHelper/Fixtures/can_index_mounted_page.xml
@@ -24,6 +24,7 @@ There is following scenario:
                 page = PAGE
                 page.typeNum = 0
                 page.bodyTag = <body>
+                config.index_enable = 1
 
                 plugin.tx_solr {
 

--- a/Tests/Integration/IndexQueue/FrontendHelper/Fixtures/can_index_multiple_mounted_page.xml
+++ b/Tests/Integration/IndexQueue/FrontendHelper/Fixtures/can_index_multiple_mounted_page.xml
@@ -25,6 +25,7 @@ There is following scenario:
         <clear>3</clear>
         <config>
             <![CDATA[
+                config.index_enable = 1
                 page = PAGE
                 page.typeNum = 0
                 page.bodyTag = <body>

--- a/Tests/Integration/IndexQueue/FrontendHelper/Fixtures/can_index_page_with_relation_to_category.xml
+++ b/Tests/Integration/IndexQueue/FrontendHelper/Fixtures/can_index_page_with_relation_to_category.xml
@@ -8,11 +8,7 @@
         <clear>3</clear>
         <config>
             <![CDATA[
-                config.sys_language_overlay = 1
-                config.sys_language_mode = content_fallback
-                config.sys_language_uid = 0
-                config.linkVars = L
-
+                config.index_enable = 1
                 page = PAGE
                 page.typeNum = 0
                 page.bodyTag = <body>

--- a/Tests/Integration/IndexQueue/FrontendHelper/Fixtures/can_index_page_with_relation_to_page.xml
+++ b/Tests/Integration/IndexQueue/FrontendHelper/Fixtures/can_index_page_with_relation_to_page.xml
@@ -8,10 +8,7 @@
         <clear>3</clear>
         <config>
             <![CDATA[
-                config.sys_language_overlay = 1
-                config.sys_language_mode = content_fallback
-                config.sys_language_uid = 0
-                config.linkVars = L
+                config.index_enable = 1
 
                 page = PAGE
                 page.typeNum = 0
@@ -60,11 +57,6 @@
                         }
                     }
                 }
-                [globalVar = GP:L = 1]
-                    plugin.tx_solr.solr.path = /solr/core_de/
-                    config.sys_language_uid = 1
-                [end]
-
             ]]>
         </config>
         <sorting>100</sorting>
@@ -119,7 +111,6 @@
         <title>German</title>
         <flag>de</flag>
         <language_isocode>de</language_isocode>
-        <static_lang_isocode>0</static_lang_isocode>
     </sys_language>
 
     <tx_solr_indexqueue_item>

--- a/Tests/Integration/IndexQueue/FrontendHelper/Fixtures/can_index_with_additional_fields_into_solr.xml
+++ b/Tests/Integration/IndexQueue/FrontendHelper/Fixtures/can_index_with_additional_fields_into_solr.xml
@@ -8,6 +8,7 @@
         <clear>3</clear>
         <config>
             <![CDATA[
+                config.index_enable = 1
                 page = PAGE
                 page.typeNum = 0
                 page.bodyTag = <body>

--- a/Tests/Integration/IndexQueue/FrontendHelper/Fixtures/can_overwrite_configuration_in_rootline.xml
+++ b/Tests/Integration/IndexQueue/FrontendHelper/Fixtures/can_overwrite_configuration_in_rootline.xml
@@ -8,6 +8,7 @@
         <clear>3</clear>
         <config>
             <![CDATA[
+                config.index_enable = 1
                 page = PAGE
                 page.typeNum = 0
                 page.bodyTag = <body>

--- a/Tests/Integration/IndexQueue/FrontendHelper/Fixtures/does_not_die_if_page_not_available.xml
+++ b/Tests/Integration/IndexQueue/FrontendHelper/Fixtures/does_not_die_if_page_not_available.xml
@@ -8,7 +8,6 @@
         <title>German</title>
         <flag>de</flag>
         <language_isocode>de</language_isocode>
-        <static_lang_isocode>0</static_lang_isocode>
     </sys_language>
 
     <sys_template>
@@ -18,10 +17,10 @@
         <clear>3</clear>
         <config>
             <![CDATA[
+                config.index_enable = 1
+                config.sys_language_uid = 3
                 config.sys_language_mode = strict
 
-                config.sys_language_uid = 0
-                config.linkVars = L
 
                 page = PAGE
                 page.typeNum = 0

--- a/Tests/Integration/IndexQueue/FrontendHelper/PageIndexerTest.php
+++ b/Tests/Integration/IndexQueue/FrontendHelper/PageIndexerTest.php
@@ -29,6 +29,7 @@ use ApacheSolrForTypo3\Solr\IndexQueue\FrontendHelper\PageIndexer;
 use ApacheSolrForTypo3\Solr\IndexQueue\PageIndexerRequest;
 use ApacheSolrForTypo3\Solr\IndexQueue\PageIndexerResponse;
 use ApacheSolrForTypo3\Solr\Tests\Integration\IntegrationTest;
+use ApacheSolrForTypo3\Solr\Util;
 use TYPO3\CMS\Core\Error\Http\PageNotFoundException;
 use TYPO3\CMS\Core\TimeTracker\TimeTracker;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -120,8 +121,8 @@ class PageIndexerTest extends IntegrationTest
 
         $this->importDataSetFromFixture('can_index_page_with_relation_to_page.xml');
 
-        $this->executePageIndexer([], 1, 0, '', '', null, '', '', 0);
-        $this->executePageIndexer([], 1, 0, '', '', null, '', '', 1);
+        $this->executePageIndexer(1, '', 0);
+        $this->executePageIndexer(1, '', 1);
 
         // do we have the record in the index with the value from the mm relation?
         $this->waitToBeVisibleInSolr('core_en');
@@ -149,7 +150,7 @@ class PageIndexerTest extends IntegrationTest
         $this->cleanUpSolrServerAndAssertEmpty('core_en');
 
         $this->importDataSetFromFixture('can_index_page_with_relation_to_category.xml');
-        $this->executePageIndexer([], 10, 0, '', '', null, '', '', 0);
+        $this->executePageIndexer(10);
 
         $this->waitToBeVisibleInSolr('core_en');
 
@@ -193,7 +194,7 @@ class PageIndexerTest extends IntegrationTest
     public function canIndexPageIntoSolrWithAdditionalFieldsFromRootLine()
     {
         $this->importDataSetFromFixture('can_overwrite_configuration_in_rootline.xml');
-        $this->executePageIndexer([], 2);
+        $this->executePageIndexer(2);
 
         // we wait to make sure the document will be available in solr
         $this->waitToBeVisibleInSolr();
@@ -266,7 +267,7 @@ class PageIndexerTest extends IntegrationTest
 
         $this->cleanUpSolrServerAndAssertEmpty();
         $this->importDataSetFromFixture('can_index_mounted_page.xml');
-        $this->executePageIndexer([], 24, 0, '', '', null, '24-14');
+        $this->executePageIndexer(24, '24-14');
 
         // we wait to make sure the document will be available in solr
         $this->waitToBeVisibleInSolr();
@@ -276,8 +277,6 @@ class PageIndexerTest extends IntegrationTest
     }
 
     /**
-     * This testcase should check if we can queue an custom record with MM relations and respect the additionalWhere clause.
-     *
      * There is following scenario:
      *
      *  [0]
@@ -302,8 +301,8 @@ class PageIndexerTest extends IntegrationTest
 
         $this->cleanUpSolrServerAndAssertEmpty();
         $this->importDataSetFromFixture('can_index_multiple_mounted_page.xml');
-        $this->executePageIndexer([], 44, 0, '', '', null, '44-14');
-        $this->executePageIndexer([], 44, 0, '', '', null, '44-24');
+        $this->executePageIndexer(44, '44-14');
+        $this->executePageIndexer(44, '44-24');
 
         // we wait to make sure the document will be available in solr
         $this->waitToBeVisibleInSolr();
@@ -312,8 +311,8 @@ class PageIndexerTest extends IntegrationTest
 
         $this->assertContains('"numFound":2', $solrContent, 'Unexpected amount of documents in the core');
 
-        $this->assertContains('"url":"index.php?id=44&MP=44-14"', $solrContent, 'Could not find document of first mounted page');
-        $this->assertContains('"url":"index.php?id=44&MP=44-24"', $solrContent, 'Could not find document of second mounted page');
+        $this->assertContains('/pages/44/44-14/', $solrContent, 'Could not find document of first mounted page');
+        $this->assertContains('/pages/44/44-24/', $solrContent, 'Could not find document of second mounted page');
     }
 
     /**
@@ -325,11 +324,14 @@ class PageIndexerTest extends IntegrationTest
     public function phpProcessDoesNotDieIfPageIsNotAvailable() {
         $this->applyUsingErrorControllerForCMS9andAbove();
         $this->registerShutdownFunctionToPrintExplanationOf404HandlingOnCMSIfDieIsCalled();
-        $this->expectException(PageNotFoundException::class);
-
+        if (Util::getIsTYPO3VersionBelow10()) {
+            $this->expectException(PageNotFoundException::class);
+        } else {
+            $this->expectException(\InvalidArgumentException::class);
+        }
 
         $this->importDataSetFromFixture('does_not_die_if_page_not_available.xml');
-        $this->executePageIndexer(null, null, null, null, null, null, null, null, 3, ['sys_language_mode' => 'strict']);
+        $this->executePageIndexer(null);
     }
 
     /**
@@ -368,21 +370,13 @@ class PageIndexerTest extends IntegrationTest
      * @param int $languageId
      * @throws \TYPO3\CMS\Core\Error\Http\ServiceUnavailableException
      */
-    protected function executePageIndexer($typo3ConfVars = [], $pageId = 1, $type = 0, $no_cache = '', $cHash = '', $_2 = null, $MP = '', $RDCT = '', $languageId = 0, $additionalConfigs = [])
+    protected function executePageIndexer($pageId = 1, $MP = '', $languageId = 0)
     {
-        GeneralUtility::_GETset($languageId, 'L');
         $GLOBALS['TT'] = $this->getMockBuilder(TimeTracker::class)->disableOriginalConstructor()->getMock();
-
-        $config = [
-            'config' => array_merge([
-                'index_enable' => 1,
-                'sys_language_uid' => $languageId
-            ], $additionalConfigs)
-        ];
 
         unset($GLOBALS['TSFE']);
 
-        $TSFE = $this->getConfiguredTSFE($typo3ConfVars, $pageId, $type, $no_cache, $cHash, $_2, $MP, $RDCT, $config);
+        $TSFE = $this->getConfiguredTSFE($pageId, $MP, $languageId);
         $TSFE->cObj = GeneralUtility::makeInstance(ContentObjectRenderer::class);
         $GLOBALS['TSFE'] = $TSFE;
 

--- a/Tests/Integration/IndexQueue/IndexerTest.php
+++ b/Tests/Integration/IndexQueue/IndexerTest.php
@@ -155,8 +155,13 @@ class IndexerTest extends IntegrationTest
         $this->waitToBeVisibleInSolr('core_de');
         $solrContent = file_get_contents($this->getSolrConnectionUriAuthority() . '/solr/core_de/select?q=*:*');
         $this->assertContains('"numFound":2', $solrContent, 'Could not find translated record in solr document into solr');
-        $this->assertContains('"title":"translation"', $solrContent, 'Could not index  translated document into solr');
-        $this->assertContains('"title":"translation2"', $solrContent, 'Could not index  translated document into solr');
+        if ($fixture === 'can_index_custom_translated_record_without_l_param_and_content_fallback.xml') {
+            $this->assertContains('"title":"original"', $solrContent, 'Could not index  translated document into solr');
+            $this->assertContains('"title":"original2"', $solrContent, 'Could not index  translated document into solr');
+        } else {
+            $this->assertContains('"title":"translation"', $solrContent, 'Could not index  translated document into solr');
+            $this->assertContains('"title":"translation2"', $solrContent, 'Could not index  translated document into solr');
+        }
         $this->assertContains('"url":"http://testone.site/de/?tx_foo%5Buid%5D=88', $solrContent, 'Can not build typolink as expected');
         $this->assertContains('"url":"http://testone.site/de/?tx_foo%5Buid%5D=777', $solrContent, 'Can not build typolink as expected');
 

--- a/Tests/Integration/IntegrationTest.php
+++ b/Tests/Integration/IntegrationTest.php
@@ -28,7 +28,6 @@ use ApacheSolrForTypo3\Solr\Access\Rootline;
 use ApacheSolrForTypo3\Solr\Typo3PageIndexer;
 
 use ApacheSolrForTypo3\Solr\Util;
-use Composer\Autoload\ClassLoader;
 use InvalidArgumentException;
 use Nimut\TestingFramework\Exception\Exception;
 use ReflectionClass;
@@ -49,7 +48,9 @@ use TYPO3\CMS\Core\Localization\LanguageService;
 use TYPO3\CMS\Core\TimeTracker\TimeTracker;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Object\ObjectManager;
+use TYPO3\CMS\Extbase\Object\ObjectManagerInterface;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
+use TYPO3\CMS\Frontend\Http\RequestHandler;
 use TYPO3\CMS\Frontend\Page\PageGenerator;
 use TYPO3\CMS\Core\Tests\Functional\SiteHandling\SiteBasedTestTrait;
 use function getenv;
@@ -69,7 +70,7 @@ abstract class IntegrationTest extends FunctionalTestCase
      */
     protected const LANGUAGE_PRESETS = [
         'EN' => ['id' => 0, 'title' => 'English', 'locale' => 'en_US.UTF8'],
-        'DE' => ['id' => 1, 'title' => 'German', 'locale' => 'de_DE.UTF8'],
+        'DE' => ['id' => 1, 'title' => 'German', 'locale' => 'de_DE.UTF8', 'fallbackType' => 'fallback', 'fallbacks' => 'EN'],
         'DA' => ['id' => 2, 'title' => 'Danish', 'locale' => 'da_DA.UTF8']
     ];
 
@@ -252,29 +253,21 @@ abstract class IntegrationTest extends FunctionalTestCase
     }
 
     /**
-     * Setup configured TSFE
-     *
-     * @param array $TYPO3_CONF_VARS
      * @param int $id
-     * @param int $type
-     * @param string $no_cache
-     * @param string $cHash
-     * @param null $_2
      * @param string $MP
-     * @param string $RDCT
-     * @param array $config
+     * @param $language
      * @return TypoScriptFrontendController
      */
-    protected function getConfiguredTSFE($TYPO3_CONF_VARS = [], $id = 1, $type = 0, $no_cache = '', $cHash = '', $_2 = null, $MP = '', $RDCT = '', $config = [])
+    protected function getConfiguredTSFE($id = 1, $MP = '', $language = 0)
     {
             /** @var TSFETestBootstrapper $bootstrapper */
         $bootstrapper = GeneralUtility::makeInstance(TSFETestBootstrapper::class);
 
         if(Util::getIsTYPO3VersionBelow10()) {
             // @todo this part can be dropped when TYPO3 9 support will be dropped
-            $result = $bootstrapper->legacyBootstrap($TYPO3_CONF_VARS, $id, $type, $no_cache, $cHash, $_2, $MP, $RDCT, $config);
+            $result = $bootstrapper->legacyBootstrap($id, $MP, $language);
         } else {
-            $result = $bootstrapper->bootstrap($TYPO3_CONF_VARS, $id, $no_cache, $cHash, $_2, $MP, $RDCT, $config);
+            $result = $bootstrapper->bootstrap($id, $MP, $language);
         }
         return $result->getTsfe();
     }
@@ -401,11 +394,20 @@ abstract class IntegrationTest extends FunctionalTestCase
         $_SERVER['HTTP_HOST'] = 'test.local.typo3.org';
         $_SERVER['REQUEST_URI'] = '/search.html';
 
-        $fakeTSFE = $this->getConfiguredTSFE([], $pageId);
+        $fakeTSFE = $this->getConfiguredTSFE($pageId);
         $fakeTSFE->newCObj();
 
         $GLOBALS['TSFE'] = $fakeTSFE;
         $this->simulateFrontedUserGroups($feUserGroupArray);
+
+        #$fakeTSFE->preparePageContentGeneration();
+        if(Util::getIsTYPO3VersionBelow10()) {
+            PageGenerator::renderContent();
+        } else {
+            $request = $GLOBALS['TYPO3_REQUEST'];
+            $requestHandler = GeneralUtility::makeInstance(RequestHandler::class);
+            $requestHandler->handle($request);
+        }
 
         return $fakeTSFE;
     }
@@ -476,7 +478,7 @@ abstract class IntegrationTest extends FunctionalTestCase
         $defaultLanguage = $this->buildDefaultLanguageConfiguration('EN', '/en/');
         $defaultLanguage['solr_core_read'] = 'core_en';
 
-        $german = $this->buildLanguageConfiguration('DE', '/de/');
+        $german = $this->buildLanguageConfiguration('DE', '/de/', ['EN'], 'fallback');
         $german['solr_core_read'] = 'core_de';
 
         $danish = $this->buildLanguageConfiguration('DA', '/da/');
@@ -554,5 +556,18 @@ abstract class IntegrationTest extends FunctionalTestCase
     {
         $solrConnectionInfo = $this->getSolrConnectionInfo();
         return $solrConnectionInfo['scheme'] . '://' . $solrConnectionInfo['host'] . ':' . $solrConnectionInfo['port'];
+    }
+
+    /**
+     * @return ObjectManagerInterface
+     */
+    protected function getFakeObjectManager(): ObjectManagerInterface
+    {
+        if(Util::getIsTYPO3VersionBelow10()) {
+            $fakeObjectManager = new \ApacheSolrForTypo3\Solr\Tests\Unit\Helper\LegacyFakeObjectManager();
+        } else {
+            $fakeObjectManager = new \ApacheSolrForTypo3\Solr\Tests\Unit\Helper\FakeObjectManager();
+        }
+        return $fakeObjectManager;
     }
 }

--- a/Tests/Integration/SearchTest.php
+++ b/Tests/Integration/SearchTest.php
@@ -442,7 +442,7 @@ class SearchTest extends IntegrationTest
 
         $GLOBALS['TT'] = $this->getMockBuilder(TimeTracker::class)->disableOriginalConstructor()->getMock();
         for ($i = 1; $i <= 15; $i++) {
-            $fakeTSFE = $this->getConfiguredTSFE([], $i);
+            $fakeTSFE = $this->getConfiguredTSFE($i);
             $GLOBALS['TSFE'] = $fakeTSFE;
 
             /** @var $pageIndexer \ApacheSolrForTypo3\Solr\Typo3PageIndexer */

--- a/Tests/Integration/UtilTest.php
+++ b/Tests/Integration/UtilTest.php
@@ -3,9 +3,18 @@ namespace ApacheSolrForTypo3\Solr\Tests\Integration;
 
 use ApacheSolrForTypo3\Solr\System\Cache\TwoLevelCache;
 use ApacheSolrForTypo3\Solr\Util;
+use Prophecy\Argument;
+use TYPO3\CMS\Core\Context\LanguageAspect;
+use TYPO3\CMS\Core\Context\UserAspect;
+use TYPO3\CMS\Core\Http\ServerRequest;
+use TYPO3\CMS\Core\Site\Entity\Site;
+use TYPO3\CMS\Core\Site\Entity\SiteLanguage;
+use TYPO3\CMS\Core\Site\SiteFinder;
 use TYPO3\CMS\Core\TypoScript\ExtendedTemplateService;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 use TYPO3\CMS\Frontend\Page\PageRepository;
+use TYPO3\CMS\Core\Context\Context;
 
 class UtilTest extends IntegrationTest
 {
@@ -16,18 +25,43 @@ class UtilTest extends IntegrationTest
         $frontendCache = $this->prophesize(\TYPO3\CMS\Core\Cache\Frontend\VariableFrontend::class);
         /** @var \TYPO3\CMS\Core\Cache\CacheManager|\Prophecy\Prophecy\ObjectProphecy $cacheManager */
         $cacheManager = $this->prophesize(\TYPO3\CMS\Core\Cache\CacheManager::class);
-        $cacheManager
-            ->getCache('cache_pages')
-            ->willReturn($frontendCache->reveal());
-        $cacheManager
-            ->getCache('cache_runtime')
-            ->willReturn($frontendCache->reveal());
-        $cacheManager
-            ->getCache('cache_hash')
-            ->willReturn($frontendCache->reveal());
-        $cacheManager
-            ->getCache('cache_core')
-            ->willReturn($frontendCache->reveal());
+
+        if (Util::getIsTYPO3VersionBelow10()) {
+
+            $cacheManager
+                ->getCache('cache_pages')
+                ->willReturn($frontendCache->reveal());
+            $cacheManager
+                ->getCache('cache_runtime')
+                ->willReturn($frontendCache->reveal());
+            $cacheManager
+                ->getCache('cache_hash')
+                ->willReturn($frontendCache->reveal());
+            $cacheManager
+                ->getCache('cache_core')
+                ->willReturn($frontendCache->reveal());
+
+
+            $cacheManager
+                ->getCache('cache_rootline')
+                ->willReturn($frontendCache->reveal());
+        } else {
+            $cacheManager
+                ->getCache('pages')
+                ->willReturn($frontendCache->reveal());
+            $cacheManager
+                ->getCache('runtime')
+                ->willReturn($frontendCache->reveal());
+            $cacheManager
+                ->getCache('hash')
+                ->willReturn($frontendCache->reveal());
+            $cacheManager
+                ->getCache('core')
+                ->willReturn($frontendCache->reveal());
+            $cacheManager
+                ->getCache('hash')
+                ->willReturn($frontendCache->reveal());
+        }
         $cacheManager
             ->getCache('tx_solr_configuration')
             ->willReturn($frontendCache->reveal());
@@ -57,12 +91,17 @@ class UtilTest extends IntegrationTest
      */
     public function getConfigurationFromPageIdReturnsCachedConfiguration()
     {
-        error_reporting(0); // needed to disable exception reporting of deprecate methods with trigger_error
         $pageId = 12;
         $path = '';
         $language = 0;
         $initializeTsfe = false;
-        $cacheId = md5($pageId . '|' . $path . '|' . $language . '|' . ($initializeTsfe ? '1' : '0'));
+        $cacheId = md5($pageId . '|' . $path . '|' . $language);
+
+        if (!Util::getIsTYPO3VersionBelow10()) {
+            $rootLineUtility = $this->prophesize(\TYPO3\CMS\Core\Utility\RootlineUtility::class);
+            $rootLineUtility->get()->shouldBeCalledOnce()->willReturn([]);
+            GeneralUtility::addInstance(\TYPO3\CMS\Core\Utility\RootlineUtility::class, $rootLineUtility->reveal());
+        }
 
         // prepare first call
 
@@ -76,11 +115,6 @@ class UtilTest extends IntegrationTest
             ->set($cacheId, [])
             ->shouldBeCalledOnce();
         GeneralUtility::addInstance(TwoLevelCache::class, $twoLevelCache->reveal());
-
-
-        $rootLineUtility = $this->prophesize(\TYPO3\CMS\Core\Utility\RootlineUtility::class);
-        $rootLineUtility->get()->shouldBeCalledOnce()->willReturn([]);
-        GeneralUtility::addInstance(\TYPO3\CMS\Core\Utility\RootlineUtility::class, $rootLineUtility->reveal());
 
         /** @var ExtendedTemplateService|\Prophecy\Prophecy\ObjectProphecy $extendedTemplateService */
         $extendedTemplateService = $this->prophesize(ExtendedTemplateService::class);
@@ -121,12 +155,11 @@ class UtilTest extends IntegrationTest
      */
     public function getConfigurationFromPageIdInitializesTsfe()
     {
-        error_reporting(0); // needed to disable exception reporting of deprecate methods with trigger_error
         $pageId = 24;
         $path = '';
         $language = 0;
         $initializeTsfe = true;
-        $cacheId = md5($pageId . '|' . $path . '|' . $language . '|' . ($initializeTsfe ? '1' : '0'));
+        $cacheId = md5($pageId . '|' . $path . '|' . $language);
 
         /** @var TwoLevelCache|\Prophecy\Prophecy\ObjectProphecy $twoLevelCache */
         $twoLevelCache = $this->prophesize(TwoLevelCache::class);
@@ -162,7 +195,6 @@ class UtilTest extends IntegrationTest
      */
     public function getConfigurationFromPageIdInitializesTsfeOnCacheCall()
     {
-        error_reporting(0); // needed to disable exception reporting of deprecate methods with trigger_error
         $path = '';
         $language = 0;
         $initializeTsfe = true;
@@ -179,6 +211,7 @@ class UtilTest extends IntegrationTest
             ->shouldBeCalled();
         GeneralUtility::addInstance(TwoLevelCache::class, $twoLevelCache->reveal());
 
+
         // Change TSFE->id to 12 ($pageId) and create new cache
         $this->buildTestCaseForTsfe(34, 1);
         Util::getConfigurationFromPageId(
@@ -194,6 +227,7 @@ class UtilTest extends IntegrationTest
         );
 
         // Change TSFE->id to 23 and create new cache
+
         $this->buildTestCaseForTsfe(56, 8);
         Util::getConfigurationFromPageId(
             56,
@@ -207,9 +241,9 @@ class UtilTest extends IntegrationTest
             $GLOBALS['TSFE']->id
         );
 
+
         // prepare second/cached call
         // TSFE->id has to be changed back to 12 $pageId
-
         Util::getConfigurationFromPageId(
             34,
             $path,
@@ -222,6 +256,7 @@ class UtilTest extends IntegrationTest
             34,
             $GLOBALS['TSFE']->id
         );
+
     }
 
     protected function buildTestCaseForTsfe(int $pageId, int $rootPageId)
@@ -234,24 +269,53 @@ class UtilTest extends IntegrationTest
         $extendedTemplateService = $this->prophesize(ExtendedTemplateService::class);
         GeneralUtility::addInstance(ExtendedTemplateService::class, $extendedTemplateService->reveal());
 
-        /** @var \ApacheSolrForTypo3\Solr\Domain\Site\Site|\Prophecy\Prophecy\ObjectProphecy $site */
-        $site = $this->prophesize(\ApacheSolrForTypo3\Solr\Domain\Site\Site::class);
-        $site
-            ->getRootPageId()
-            ->shouldBeCalled()
-            ->willReturn($rootPageId);
+        $siteLanguage = $this->prophesize(SiteLanguage::class);
 
-        /** @var \ApacheSolrForTypo3\Solr\Domain\Site\SiteRepository|\Prophecy\Prophecy\ObjectProphecy $siteRepository */
-        $siteRepository = $this->prophesize(\ApacheSolrForTypo3\Solr\Domain\Site\SiteRepository::class);
-        $siteRepository
-            ->getSiteByPageId($pageId)
+
+        $site = $this->prophesize(Site::class);
+        $site->getLanguageById(0)
+            ->shouldBeCalled()
+            ->willReturn($siteLanguage->reveal());
+        $siteFinder = $this->prophesize(SiteFinder::class);
+        $siteFinder->getSiteByPageId($pageId)
             ->shouldBeCalled()
             ->willReturn($site->reveal());
-        GeneralUtility::addInstance(\ApacheSolrForTypo3\Solr\Domain\Site\SiteRepository::class, $siteRepository->reveal());
-        
-        $tsfeProphecy = $this->prophesize(\TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController::class);
-        $tsfeProphecy->willBeConstructedWith([null, $pageId, 0]);
+
+        GeneralUtility::addInstance(SiteFinder::class, $siteFinder->reveal());
+
+        $tsfeProphecy = $this->prophesize(TypoScriptFrontendController::class);
+        if (Util::getIsTYPO3VersionBelow10()) {
+            $tsfeProphecy->willBeConstructedWith([null, $pageId, 0]);
+        } else {
+            $siteLanguage->getTypo3Language()->shouldBeCalled()->willReturn(0);
+
+            $rootLineUtility = $this->prophesize(\TYPO3\CMS\Core\Utility\RootlineUtility::class);
+            $rootLineUtility->get()->shouldBeCalledOnce()->willReturn([]);
+            GeneralUtility::addInstance(\TYPO3\CMS\Core\Utility\RootlineUtility::class, $rootLineUtility->reveal());
+
+            $frontendUserAspect = $this->prophesize(UserAspect::class);
+
+            $context = $this->prophesize(Context::class);
+            $context->hasAspect('frontend.preview')->shouldBeCalled()->willReturn(false);
+            $context->setAspect('frontend.preview', Argument::any())->shouldBeCalled();
+            $context->hasAspect('frontend.user')->shouldBeCalled()->willReturn(false);
+            $context->hasAspect('language')->shouldBeCalled()->willReturn(true);
+            $context->getPropertyFromAspect('language', 'id')->shouldBeCalled()->willReturn(0);
+            $context->getPropertyFromAspect('language', 'id', 0)->shouldBeCalled()->willReturn(0);
+            $context->getAspect('frontend.user')->shouldBeCalled()->willReturn($frontendUserAspect->reveal());
+            $context->getPropertyFromAspect('visibility', 'includeHiddenContent', false)->shouldBeCalled();
+            $context->getPropertyFromAspect('backend.user', 'isLoggedIn', false)->shouldBeCalled();
+            $context->setAspect('frontend.user', Argument::any())->shouldBeCalled();
+            $context->getPropertyFromAspect('workspace', 'id')->shouldBeCalled()->willReturn(0);
+            $context->getPropertyFromAspect('visibility', 'includeHiddenPages')->shouldBeCalled()->willReturn(false);
+            $context->setAspect('typoscript', Argument::any())->shouldBeCalled();
+            GeneralUtility::setSingletonInstance(Context::class, $context->reveal());
+            $GLOBALS['TYPO3_REQUEST'] = GeneralUtility::makeInstance(ServerRequest::class);
+            $tsfeProphecy->willBeConstructedWith([$context->reveal(), $site->reveal(), $siteLanguage->reveal()]);
+        }
+
         $tsfe = $tsfeProphecy->reveal();
-        GeneralUtility::addInstance(\TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController::class, $tsfe);
+        $tsfe->tmpl = new \TYPO3\CMS\Core\TypoScript\TemplateService();
+        GeneralUtility::addInstance(TypoScriptFrontendController::class, $tsfe);
     }
 }

--- a/Tests/Unit/Domain/Search/ResultSet/ResultSetReconstitutionProcessorTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/ResultSetReconstitutionProcessorTest.php
@@ -34,11 +34,7 @@ use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Facets\OptionBased\QueryGrou
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\ResultSetReconstitutionProcessor;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
 use ApacheSolrForTypo3\Solr\Tests\Unit\Helper\FakeObjectManager;
-use TYPO3\CMS\Core\TimeTracker\TimeTracker;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
-use TYPO3\CMS\Frontend\ContentObject\CaseContentObject;
-use TYPO3\CMS\Frontend\ContentObject\TextContentObject;
+use ApacheSolrForTypo3\Solr\Util;
 
 /**
  * Unit test case for the ObjectReconstitutionProcessor.
@@ -108,7 +104,6 @@ class ResultSetReconstitutionProcessorTest extends UnitTest
         $configuration = $this->getConfigurationArrayFromFacetConfigurationArray($facetConfiguration);
         $processor = $this->getConfiguredReconstitutionProcessor($configuration, $searchResultSet);
         $processor->process($searchResultSet);
-
         // after the reconstitution they should be 1 facet present
         $this->assertCount(1, $searchResultSet->getFacets());
     }
@@ -1123,7 +1118,13 @@ class ResultSetReconstitutionProcessorTest extends UnitTest
         $searchResultSet->getUsedSearchRequest()->expects($this->any())->method('getActiveFacetNames')->will($this->returnValue([]));
 
         $processor = new ResultSetReconstitutionProcessor();
-        $processor->setObjectManager(new FakeObjectManager());
+
+        if(Util::getIsTYPO3VersionBelow10()) {
+            $fakeObjectManager = new \ApacheSolrForTypo3\Solr\Tests\Unit\Helper\LegacyFakeObjectManager();
+        } else {
+            $fakeObjectManager = new \ApacheSolrForTypo3\Solr\Tests\Unit\Helper\FakeObjectManager();
+        }
+        $processor->setObjectManager($fakeObjectManager);
         return $processor;
     }
 }

--- a/Tests/Unit/Domain/Search/ResultSet/SearchResultSetServiceTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/SearchResultSetServiceTest.php
@@ -26,12 +26,14 @@ namespace ApacheSolrForTypo3\Solr\Tests\Unit\Domain\Search\ResultSet;
 
 use ApacheSolrForTypo3\Solr\Domain\Search\Query\QueryBuilder;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\Result\SearchResultBuilder;
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
 use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSetService;
 use ApacheSolrForTypo3\Solr\Domain\Search\SearchRequest;
 use ApacheSolrForTypo3\Solr\Search;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
 use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
+use TYPO3\CMS\Extbase\Object\ObjectManager;
 
 /**
  * @author Timo Hund <timo.hund@dkd.de>
@@ -64,6 +66,11 @@ class SearchResultSetServiceTest extends UnitTest
     protected $searchResultBuilderMock;
 
     /**
+     * @var ObjectManager
+     */
+    protected $objectManagerMock = null;
+
+    /**
      * @var QueryBuilder
      */
     protected $queryBuilderMock;
@@ -76,6 +83,8 @@ class SearchResultSetServiceTest extends UnitTest
         $this->searchResultBuilderMock = $this->getDumbMock(SearchResultBuilder::class);
         $this->queryBuilderMock = $this->getDumbMock(QueryBuilder::class);
         $this->searchResultSetService = new SearchResultSetService($this->configurationMock, $this->searchMock, $this->logManagerMock, $this->searchResultBuilderMock, $this->queryBuilderMock);
+        $this->objectManagerMock = $this->getMockBuilder(ObjectManager::class)->disableOriginalConstructor()->getMock();
+        $this->searchResultSetService->injectObjectManager($this->objectManagerMock);
     }
 
     /**
@@ -86,6 +95,7 @@ class SearchResultSetServiceTest extends UnitTest
         $searchRequest = new SearchRequest();
         $searchRequest->setRawQueryString(null);
         $this->assertAllInitialSearchesAreDisabled();
+        $this->objectManagerMock->expects($this->once())->method('get')->with(SearchResultSet::class)->willReturn(new SearchResultSet());
         $resultSet = $this->searchResultSetService->search($searchRequest);
         $this->assertFalse($resultSet->getHasSearched(), 'Search should not be executed when empty query string was passed');
     }
@@ -98,6 +108,7 @@ class SearchResultSetServiceTest extends UnitTest
         $searchRequest = new SearchRequest();
         $searchRequest->setRawQueryString("");
         $this->configurationMock->expects($this->once())->method('getSearchQueryAllowEmptyQuery')->willReturn(false);
+        $this->objectManagerMock->expects($this->once())->method('get')->with(SearchResultSet::class)->willReturn(new SearchResultSet());
         $resultSet = $this->searchResultSetService->search($searchRequest);
         $this->assertFalse($resultSet->getHasSearched(), 'Search should not be executed when empty query string was passed');
     }

--- a/Tests/Unit/Domain/Search/ResultSet/SearchResultSetTest.php
+++ b/Tests/Unit/Domain/Search/ResultSet/SearchResultSetTest.php
@@ -36,7 +36,8 @@ use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\System\Logging\SolrLogManager;
 use ApacheSolrForTypo3\Solr\System\Solr\ResponseAdapter;
 use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
-use Solarium\Core\Client\Response;
+use TYPO3\CMS\Extbase\Object\ObjectManager;
+use ApacheSolrForTypo3\Solr\Domain\Search\ResultSet\SearchResultSet;
 
 
 /**
@@ -81,6 +82,11 @@ class SearchResultSetTest extends UnitTest
     protected $escapeServiceMock;
 
     /**
+     * @var ObjectManager
+     */
+    protected $objectManagerMock = null;
+
+    /**
      * @return void
      */
     public function setUp()
@@ -97,6 +103,8 @@ class SearchResultSetTest extends UnitTest
             ->setMethods(['getRegisteredSearchComponents'])
             ->setConstructorArgs([$this->configurationMock, $this->searchMock, $this->solrLogManagerMock])
             ->getMock();
+        $this->objectManagerMock = $this->getMockBuilder(ObjectManager::class)->disableOriginalConstructor()->getMock();
+        $this->searchResultSetService->injectObjectManager($this->objectManagerMock);
     }
 
     /**
@@ -127,6 +135,7 @@ class SearchResultSetTest extends UnitTest
         $fakeRequest = new SearchRequest(['tx_solr' => ['q' => 'my search']]);
         $fakeRequest->setResultsPerPage(10);
 
+        $this->objectManagerMock->expects($this->once())->method('get')->with(SearchResultSet::class)->willReturn(new SearchResultSet());
         $resultSet = $this->searchResultSetService->search($fakeRequest);
         $this->assertSame($resultSet->getResponse(), $fakeResponse, 'Did not get the expected fakeResponse');
     }
@@ -145,6 +154,7 @@ class SearchResultSetTest extends UnitTest
         $fakeRequest = new SearchRequest(['tx_solr' => ['q' => 'my 2. search','page' => 3]]);
         $fakeRequest->setResultsPerPage(25);
 
+        $this->objectManagerMock->expects($this->once())->method('get')->with(SearchResultSet::class)->willReturn(new SearchResultSet());
         $resultSet = $this->searchResultSetService->search($fakeRequest);
         $this->assertSame($resultSet->getResponse(), $fakeResponse, 'Did not get the expected fakeResponse');
     }
@@ -169,6 +179,7 @@ class SearchResultSetTest extends UnitTest
         $fakeRequest = new SearchRequest(['tx_solr' => ['q' => 'my 3. search']]);
         $fakeRequest->setResultsPerPage(10);
 
+        $this->objectManagerMock->expects($this->once())->method('get')->with(SearchResultSet::class)->willReturn(new SearchResultSet());
         $resultSet = $this->searchResultSetService->search($fakeRequest);
         $this->assertSame($resultSet->getResponse(), $fakeResponse, 'Did not get the expected fakeResponse');
     }
@@ -192,6 +203,9 @@ class SearchResultSetTest extends UnitTest
 
         $fakeRequest = new SearchRequest(['tx_solr' => ['q' => 'my 4. search']]);
         $fakeRequest->setResultsPerPage(10);
+
+        $this->objectManagerMock->expects($this->at(0))->method('get')->with(SearchResultSet::class)->willReturn(new SearchResultSet());
+        $this->objectManagerMock->expects($this->at(1))->method('get')->with($testProcessor)->willReturn(new TestSearchResultSetProcessor());
 
         $resultSet  = $this->searchResultSetService->search($fakeRequest);
 
@@ -224,6 +238,7 @@ class SearchResultSetTest extends UnitTest
 
         $this->assertOneSearchWillBeTriggeredWithQueryAndShouldReturnFakeResponse('test', 0, $fakeResponse);
 
+        $this->objectManagerMock->expects($this->once())->method('get')->with(SearchResultSet::class)->willReturn(new SearchResultSet());
         $resultSet = $this->searchResultSetService->search($fakeRequest);
 
         $this->assertSame($resultSet->getResponse(), $fakeResponse, 'Did not get the expected fakeResponse');
@@ -251,6 +266,7 @@ class SearchResultSetTest extends UnitTest
         $fakeRequest = new SearchRequest(['tx_solr' => ['q' => 'variantsSearch']]);
         $fakeRequest->setResultsPerPage(10);
 
+        $this->objectManagerMock->expects($this->once())->method('get')->with(SearchResultSet::class)->willReturn(new SearchResultSet());
         $resultSet = $this->searchResultSetService->search($fakeRequest);
         $this->assertSame(1, count($resultSet->getSearchResults()), 'Unexpected amount of document');
 

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -120,28 +120,28 @@ if (!is_array($GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['scheduler']['tasks'][\T
 
 // registering the eID scripts
 // TODO move to suggest form modifier
-$TYPO3_CONF_VARS['FE']['eID_include']['tx_solr_api'] = 'EXT:solr/Classes/Eid/Api.php';
+$GLOBALS['TYPO3_CONF_VARS']['FE']['eID_include']['tx_solr_api'] = 'EXT:solr/Classes/Eid/Api.php';
 
 # ----- # ----- # ----- # ----- # ----- # ----- # ----- # ----- # ----- #
 
 // add custom Solr content objects
 
-$TYPO3_CONF_VARS['SC_OPTIONS']['tslib/class.tslib_content.php']['cObjTypeAndClass'][\ApacheSolrForTypo3\Solr\ContentObject\Multivalue::CONTENT_OBJECT_NAME] = [
+$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_content.php']['cObjTypeAndClass'][\ApacheSolrForTypo3\Solr\ContentObject\Multivalue::CONTENT_OBJECT_NAME] = [
     \ApacheSolrForTypo3\Solr\ContentObject\Multivalue::CONTENT_OBJECT_NAME,
     \ApacheSolrForTypo3\Solr\ContentObject\Multivalue::class
 ];
 
-$TYPO3_CONF_VARS['SC_OPTIONS']['tslib/class.tslib_content.php']['cObjTypeAndClass'][\ApacheSolrForTypo3\Solr\ContentObject\Content::CONTENT_OBJECT_NAME] = [
+$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_content.php']['cObjTypeAndClass'][\ApacheSolrForTypo3\Solr\ContentObject\Content::CONTENT_OBJECT_NAME] = [
     \ApacheSolrForTypo3\Solr\ContentObject\Content::CONTENT_OBJECT_NAME,
     \ApacheSolrForTypo3\Solr\ContentObject\Content::class
 ];
 
-$TYPO3_CONF_VARS['SC_OPTIONS']['tslib/class.tslib_content.php']['cObjTypeAndClass'][\ApacheSolrForTypo3\Solr\ContentObject\Relation::CONTENT_OBJECT_NAME] = [
+$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_content.php']['cObjTypeAndClass'][\ApacheSolrForTypo3\Solr\ContentObject\Relation::CONTENT_OBJECT_NAME] = [
     \ApacheSolrForTypo3\Solr\ContentObject\Relation::CONTENT_OBJECT_NAME,
     \ApacheSolrForTypo3\Solr\ContentObject\Relation::class
 ];
 
-$TYPO3_CONF_VARS['SC_OPTIONS']['tslib/class.tslib_content.php']['cObjTypeAndClass'][\ApacheSolrForTypo3\Solr\ContentObject\Classification::CONTENT_OBJECT_NAME] = [
+$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_content.php']['cObjTypeAndClass'][\ApacheSolrForTypo3\Solr\ContentObject\Classification::CONTENT_OBJECT_NAME] = [
     \ApacheSolrForTypo3\Solr\ContentObject\Classification::CONTENT_OBJECT_NAME,
     \ApacheSolrForTypo3\Solr\ContentObject\Classification::class
 ];


### PR DESCRIPTION
* Adapt Tests to run with TYPO3 9 and 10
* rm POST QueryStringMethode in Backend-Template form-tag
* Introduce FrontendEnvironment and move TSFE and TypoScript related stuff from Util to FrontendEnvironment (as Preparation for more TSFE Cleanups)
* rm TSFE::initTemplate() Calls (#2446)
* rm ExtendedTemplateService::init() Calls(#2445)
* rm GeneralUtility::_GETset() Calls (#2444)